### PR TITLE
デプロイに関して、nginx周りの設定を変更

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ POSTGRES_PASSWORD=Endeavor
 PGPASSWORD=Endeavor
 POSTGRES_DB=test
 TZ=Asia/Tokyo
+JWT_SECRET_KEY=secret

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  web:
+    restart: always
+
+  backend:
+    restart: always
+
+  database:
+    restart: always
+    volumes:
+      - "psql:/var/lib/postgresql/data"
+
+volumes:
+  psql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - "80:80"
     networks:
       - web
+    depends_on:
+      - backend
 
   backend:
     build: server/app
@@ -18,6 +20,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+      JWT_SECRET_KEY: secret
       TZ: ${TZ}
     networks:
       - web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
-      JWT_SECRET_KEY: secret
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
       TZ: ${TZ}
     networks:
       - web

--- a/server/app/Dockerfile
+++ b/server/app/Dockerfile
@@ -16,5 +16,6 @@ WORKDIR /server
 COPY --from=builder /server/package*.json ./
 COPY --from=builder /server/node_modules ./node_modules
 COPY --from=builder /server/dist ./dist
+COPY --from=builder /server/src ./src
 
 CMD ["node", "dist/main.js"]

--- a/server/app/Dockerfile
+++ b/server/app/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /server
 COPY --from=builder /server/package*.json ./
 COPY --from=builder /server/node_modules ./node_modules
 COPY --from=builder /server/dist ./dist
-COPY --from=builder /server/src ./src
+COPY --from=builder /server/src/data-source.ts ./src/
+COPY --from=builder /server/src/migrations ./src/migrations
 
 CMD ["node", "dist/main.js"]

--- a/web/app/src/api/base.ts
+++ b/web/app/src/api/base.ts
@@ -18,7 +18,7 @@ export async function baseAPI<
     controller.abort();
   }, 10 * 1000); // デフォルトでは10秒でタイムアウト
 
-  const res = await fetch(`http://localhost:3000/${endpoint}`, {
+  const res = await fetch(`/api/${endpoint}`, {
     method,
     mode: "cors",
     headers: {

--- a/web/app/vite.config.ts
+++ b/web/app/vite.config.ts
@@ -8,4 +8,13 @@ export default defineConfig({
   css: {
     postcss,
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:3000",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
+  },
 });

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -7,5 +7,16 @@ server {
 
     access_log /var/log/nginx/access.log;
     error_log  /var/log/nginx/error.log;
+  
+    location /api/ {
+      proxy_pass http://baba_backend:3000/;
+      proxy_redirect  off;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Server $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 }
 


### PR DESCRIPTION
## 実現したいこと
ngrokでデプロイし、実証実験が行えるようにしたい

## 背景
作業前はデプロイ時にweb側とserver側のネットワークの繋ぎ込みが上手くいかず、ページは表示されるがapiは叩けないという状態であった。この部分を解消することでngrokでのデプロイを可能にすることを試みた。

## 作業結果
ngrokを用いて本番環境でアプリにアクセスすることが可能になった。
松田さんに感謝🙏
実際に以下の手順でデプロイが可能。
1. `docker compose up -d --build`
2. `ngrok http 80`

※セッションはngrok無課金の場合8時間までは持ちますが、それ以上セッションを長持ちさせたい場合は課金する必要があります。
また、デプロイ後のURLの固定にも、課金が必要です。

## 注意事項
本PRがmergeされた後のdevからブランチをきる場合は以下手順を行う必要がある。
1. /.envに`JWT_SECRET_KEY=secret`を追記
4. `docker compose up -d --build`でdockerfile等を再ビルド
5. いつも通り`yarn all-dev`でコンテナが立ち上がる