### PR TITLE
nginx周りの設定変更に対する軽微な修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ POSTGRES_PASSWORD=Endeavor
 PGPASSWORD=Endeavor
 POSTGRES_DB=test
 TZ=Asia/Tokyo
+JWT_SECRET_KEY=secret

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  web:
+    restart: always
+
+  backend:
+    restart: always
+
+  database:
+    restart: always
+    volumes:
+      - "psql:/var/lib/postgresql/data"
+
+volumes:
+  psql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
-      JWT_SECRET_KEY: secret
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
       TZ: ${TZ}
     networks:
       - web

--- a/server/app/Dockerfile
+++ b/server/app/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /server
 COPY --from=builder /server/package*.json ./
 COPY --from=builder /server/node_modules ./node_modules
 COPY --from=builder /server/dist ./dist
-COPY --from=builder /server/src ./src
+COPY --from=builder /server/src/data-source.ts ./src/
+COPY --from=builder /server/src/migrations ./src/migrations
 
 CMD ["node", "dist/main.js"]

--- a/web/app/vite.config.ts
+++ b/web/app/vite.config.ts
@@ -8,4 +8,13 @@ export default defineConfig({
   css: {
     postcss,
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:3000",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
+  },
 });


### PR DESCRIPTION
# 概要
#35 で生じた変更に対して、微修正。

# 変更点
- (root)
  - docker-compose.yml: ハードコードされていたJWT_SECRET_KEYを環境変数を参照するように変更
  - docker-compose.override.yml(新規): コンテナ自動再起動とpostgresql用volumeを使うために追加
  - .env.example: JWT_SECRET_KEY環境変数を追加

- (server)
  - Dockerfile: migrationに必要なファイルのみコピーするように変更

追記(2023/6/21 4:48)
- (web)
  - vite.config.ts: nginxのエンドポイントに合わせてローカルwebサーバにもリバースプロキシの設定を追加

# 制約
webが叩くエンドポイントを開発環境と本番環境で切り替えるところは未実装。(web/app/src/api/base.tsの21行目)

ビルド時(yarn build)に変更できれば良さそうですが、その方法を調査中です。

追記(2023/6/21 4:48):ローカルnode環境で動くように修正しました。