### PR TITLE
予約ステータス変更機能(バックエンド)

### DIFF
--- a/server/app/src/reservation/dto/update-reservation-for-packed.dto.ts
+++ b/server/app/src/reservation/dto/update-reservation-for-packed.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsUUID } from 'class-validator';
+
+export class UpdateReservationForPackedDto {
+  @IsNotEmpty()
+  @IsUUID()
+  shipperId: string;
+}

--- a/server/app/src/reservation/reservation.controller.ts
+++ b/server/app/src/reservation/reservation.controller.ts
@@ -4,12 +4,15 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  Param,
   Post,
+  Put,
   UseGuards,
 } from '@nestjs/common';
 import { GetAccount } from 'src/account/get-account.decorator';
 import { JwtAuthGuard } from 'src/account/jwt-auth.guard';
 import { CreateReservationDto } from './dto/create-reservation.dto';
+import { UpdateReservationForPackedDto } from './dto/update-reservation-for-packed.dto';
 import { Reservation, TReservation } from './entities/reservation.entity';
 import { ReservationService } from './reservation.service';
 import { Account } from 'src/account/entities/account.entity';
@@ -40,6 +43,41 @@ export class ReservationController {
     return this.reservationService.createReservation(
       createReservationDto,
       account,
+    );
+  }
+
+  @Put('/products/:reservationId/packed')
+  async updateReservationForPacked(
+    @GetAccount() account: Account,
+    @Param('reservationId') reservationId: string,
+    @Body() updateReservationForPackedDto: UpdateReservationForPackedDto,
+  ): Promise<TReservation> {
+    return this.reservationService.updateReservationForPacked(
+      account,
+      reservationId,
+      updateReservationForPackedDto,
+    );
+  }
+
+  @Put('/products/:reservationId/kept')
+  async updateReservationForKept(
+    @GetAccount() account: Account,
+    @Param('reservationId') reservationId: string,
+  ): Promise<TReservation> {
+    return this.reservationService.updateReservationForKept(
+      account,
+      reservationId,
+    );
+  }
+
+  @Put('/products/:reservationId/received')
+  async updateReservationForReceived(
+    @GetAccount() account: Account,
+    @Param('reservationId') reservationId: string,
+  ): Promise<TReservation> {
+    return this.reservationService.updateReservationForReceived(
+      account,
+      reservationId,
     );
   }
 }

--- a/server/app/src/reservation/reservation.service.ts
+++ b/server/app/src/reservation/reservation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import * as dayjs from 'dayjs';
 import { Account, USER_ATTRIBUTE } from 'src/account/entities/account.entity';
@@ -10,6 +10,7 @@ import {
   Repository,
 } from 'typeorm';
 import { CreateReservationDto } from './dto/create-reservation.dto';
+import { UpdateReservationForPackedDto } from './dto/update-reservation-for-packed.dto';
 import {
   Reservation,
   RESERVATION_STATUS,
@@ -123,5 +124,95 @@ export class ReservationService {
     reservation.desiredAt = dayjs(dto.desiredAt).toDate();
     reservation.receiveLocationId = dto.receiveLocationId;
     reservation.status = RESERVATION_STATUS.packking;
+  }
+
+  async updateReservationForPacked(
+    account: Account,
+    reservationId: string,
+    dto: UpdateReservationForPackedDto,
+  ): Promise<TReservation> {
+    if (account.attribute !== USER_ATTRIBUTE.producer) {
+      throw new BadRequestException();
+    }
+
+    const reservation = await this.reservationRepository
+      .findOne({
+        where: { id: reservationId },
+        relations: ['product'],
+      })
+      .then((reservation) => reservation.convertTReservation());
+
+    if (!reservation) {
+      throw new BadRequestException();
+    }
+    if (account.id !== reservation.product.producerId) {
+      throw new BadRequestException();
+    }
+    if (reservation.status !== RESERVATION_STATUS.packking) {
+      throw new BadRequestException();
+    }
+
+    reservation.status = RESERVATION_STATUS.shipping;
+    reservation.shipperId = dto.shipperId;
+    reservation.packedAt = new Date();
+    this.reservationRepository.save(reservation);
+    return reservation;
+  }
+
+  async updateReservationForKept(
+    account: Account,
+    reservationId: string,
+  ): Promise<TReservation> {
+    if (account.attribute !== USER_ATTRIBUTE.intermediary) {
+      throw new BadRequestException();
+    }
+
+    const reservation = await this.reservationRepository
+      .findOne({ where: { id: reservationId } })
+      .then((reservation) => reservation.convertTReservation());
+
+    if (!reservation) {
+      throw new BadRequestException();
+    }
+    if (account.id !== reservation.receiveLocationId) {
+      throw new BadRequestException();
+    }
+    if (reservation.status !== RESERVATION_STATUS.shipping) {
+      throw new BadRequestException();
+    }
+
+    reservation.status = RESERVATION_STATUS.keeping;
+    reservation.shippedAt = new Date();
+    reservation.keptAt = new Date();
+    this.reservationRepository.save(reservation);
+    return reservation;
+  }
+
+  async updateReservationForReceived(
+    account: Account,
+    reservationId: string,
+  ): Promise<TReservation> {
+    if (account.attribute !== USER_ATTRIBUTE.consumer) {
+      throw new BadRequestException();
+    }
+
+    const reservation = await this.reservationRepository
+      .findOne({ where: { id: reservationId } })
+      .then((reservation) => reservation.convertTReservation());
+
+    if (!reservation) {
+      throw new BadRequestException();
+    }
+    if (account.id !== reservation.consumerId) {
+      throw new BadRequestException();
+    }
+    if (reservation.status !== RESERVATION_STATUS.keeping) {
+      throw new BadRequestException();
+    }
+
+    reservation.status = RESERVATION_STATUS.completed;
+    reservation.receivedAt = new Date();
+    this.reservationRepository.save(reservation);
+    return reservation;
   }
 }

--- a/web/app/src/models/Reservation.ts
+++ b/web/app/src/models/Reservation.ts
@@ -1,10 +1,12 @@
 import type { TReservation as BaseTReservation } from "./../../../../server/app/src/reservation/entities/reservation.entity";
 import type { CreateReservationDto } from "./../../../../server/app/src/reservation/dto/create-reservation.dto";
+import type { UpdateReservationForPackedDto } from "./../../../../server/app/src/reservation/dto/update-reservation-for-packed.dto";
 import type { Jsonify } from "type-fest";
 import { baseAPI } from "../api/base";
 
 export type TReservation = Jsonify<BaseTReservation>;
 export type TReservationForm = Jsonify<CreateReservationDto>;
+export type TReservationPackedForm = Jsonify<UpdateReservationForPackedDto>;
 
 export const statusToText: Record<TReservation["status"], string> = {
   canceled: "キャンセル",
@@ -44,6 +46,31 @@ export class ReservationRepository {
       endpoint: `${this.baseEndpoint}`,
       method: "POST",
       body,
+    });
+  }
+
+  async packed(
+    id: string,
+    body: TReservationPackedForm
+  ): Promise<TReservation> {
+    return await baseAPI<TReservation>({
+      endpoint: `${this.baseEndpoint}/products/${id}/packed`,
+      method: "PUT",
+      body,
+    });
+  }
+
+  async kept(id: string): Promise<TReservation> {
+    return await baseAPI<TReservation>({
+      endpoint: `${this.baseEndpoint}/products/${id}/kept`,
+      method: "PUT",
+    });
+  }
+
+  async received(id: string): Promise<TReservation> {
+    return await baseAPI<TReservation>({
+      endpoint: `${this.baseEndpoint}/products/${id}/received`,
+      method: "PUT",
     });
   }
 }


### PR DESCRIPTION
# 概要

予約ステータス変更機能のバックエンド側を実装しました。
「出荷準備中」から「受取完了」までのステータス更新処理をフロントで実装できるようになりました。

# 変更点

* (server)

  * reservations/products/{id}/packed APIを新規作成。
  　→ 予約ステータスを packing から shipping に更新する。
  　→ 配送者をリクエストボディで指定されたIDで更新する。

  * reservations/products/{id}/kept APIを新規作成。
  　→ 予約ステータスを shipping から keeping に更新する。

  * reservations/products/{id}/received APIを新規作成。
  　→ 予約ステータスを keeping から completed に更新する。
 
* (web)

  * ReservationRepository クラスに、新規作成したAPIの呼び出しメソッドを追加。