### PR TITLE
出品詳細画面のデザインを要件定義書に合わせて調整

### DIFF
--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -91,11 +91,10 @@
       />
     </div>
 
-    <Paper class="mt-3 w-[300px]" color="secondary" variant="outlined">
-      <p>
-        {product.description}
-      </p>
-    </Paper>
+    <fieldset class="p-3 w-[300px] border border-secondary rounded">
+      <legend>説明</legend>
+      {product.description}
+    </fieldset>
 
     <Paper class="mt-3 w-[300px]" color="secondary" variant="outlined">
       <div class="text-center text-base text-[#5A5A5A] mt-2">

--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -7,6 +7,9 @@
   import { addToast } from "../../../stores/Toast";
   import { markAsLogoutState } from "../../../stores/Login";
   import { CROP_UNITS_LABEL } from "../../../constants/product";
+  import dayjs from "dayjs";
+  import { USER_ATTRIBUTE } from "../../../constants/account";
+  import { profile } from "../../../stores/Account";
 
   async function fetchProduct(): Promise<TProduct> {
     try {
@@ -32,102 +35,98 @@
       return null;
     }
   }
-
-  // onMount(async () => {
-  //   $accountIdStore;
-  // });
 </script>
 
 {#await fetchProduct()}
-  <div style="display: flex; justify-content: center">
+  <div class="flex justify-center">
     <CircularProgress style="height: 160px; width: 32px;" indeterminate />
   </div>
-{:then product}
-  <div class="container">
-    <img
-      class="w-full h-auto"
-      src={product.image ??
-        "https://girlydrop.com/wp-content/uploads/post/p5774.jpg"}
-      alt=""
-    />
-    <div>
-      <h1 class="text-3xl font-bold text-[#5A5A5A] my-6">
-        {product.name}
-      </h1>
-
+{:then productData}
+  <div class="grid justify-center">
+    <div class="container">
       <div class="flex">
-        {#if product.producer.image}
-          <div class="w-[90px] h-[90px] rounded-[50%]">
-            <img
-              class="w-[90px] h-[90px] rounded-[50%]"
-              src={product.producer.image}
-              alt=""
-            />
-          </div>
-        {:else if product.producer.classification === "individual"}
+        {#if productData.producer.image}
           <img
-            class="w-[90px] h-[90px] rounded-[50%]"
-            src="./../../../../public/images/farmer.png"
+            class="w-[40px] h-[40px] rounded-[50%]"
+            src={productData.producer.image}
             alt=""
           />
-        {:else if product.producer.classification === "corporate"}
+        {:else if productData.producer.classification === "individual"}
           <img
-            class="w-[90px] h-[90px] rounded-[50%]"
-            src="./../../../../public/images/house.png"
+            class="w-[40px] h-[40px] rounded-[50%]"
+            src="./../../../public/images/farmer.png"
+            alt=""
+          />
+        {:else if productData.producer.classification === "corporate"}
+          <img
+            class="w-[40px] h-[40px] rounded-[50%]"
+            src="./../../../public/images/house.png"
             alt=""
           />
         {/if}
-        <div class="ml-4 mt-5">
-          <p class="text-[#8A8A8A] mb-1">
-            {product.producer.address}
-          </p>
-          <div class="text-3xl text-[#8A8A8A]">
-            {product.producer.name}
+        <div class="ml-4 mt-3">
+          <div class="text-xl text-[#8A8A8A]">
+            {productData.producer.name}
           </div>
         </div>
       </div>
+      <h1 class="mt-3 text-2xl font-bold text-[#5A5A5A]">
+        {productData.name}
+      </h1>
+      <img
+        src={productData.image ??
+          "./../../../public/images/default_product_image.png"}
+        alt=""
+        width="300"
+        class="mt-3"
+      />
+    </div>
 
-      <Paper
-        class="mt-5 flex justify-between"
+    <Paper class="mt-3 w-[300px]" color="secondary" variant="outlined">
+      <p>
+        {productData.description}
+      </p>
+    </Paper>
+
+    <Paper class="mt-3 w-[300px]" color="secondary" variant="outlined">
+      <div class="text-center text-base text-[#5A5A5A] mt-2">
+        {productData.unitQuantity}{CROP_UNITS_LABEL[
+          productData.unit
+        ]}あたり{productData.unitPrice}円
+      </div>
+      <div class="text-center text-base text-[#5A5A5A] mt-2">
+        残りあと{productData.remaining}点
+      </div>
+      <div class="text-center text-base text-[#5A5A5A] mt-2">
+        予約期間：
+        {dayjs(productData.startAt).format("MM/DD HH:mm")}
+        -
+        {dayjs(productData.endAt).format("MM/DD HH:mm")}
+      </div>
+    </Paper>
+
+    <div class="flex justify-center">
+      <Button
         color="secondary"
-        variant="outlined"
+        variant="raised"
+        class="w-[150px] px-4 py-2 mt-10 mr-4 rounded-full"
+        on:click={() => $goto("../../../product/")}
+        type="button"
       >
-        <div class="">
-          <div>
-            残りあと{product.remaining}点
-          </div>
-          <div class="text-lg">
-            {product.name}
-          </div>
+        <p class="black">キャンセル</p>
+      </Button>
+      {#if $profile.attribute === USER_ATTRIBUTE.consumer}
+        <div class="flex justify-center">
+          <Button
+            variant="raised"
+            class="w-[150px] px-4 py-2 mt-10 rounded-full"
+            color="secondary"
+            on:click={$goto("../../reservation/new", { productId: $params.id })}
+          >
+            <p class="black">予約</p>
+          </Button>
         </div>
-        <div class="text-2xl text-[#5A5A5A] mt-4">
-          {product.unitQuantity}{CROP_UNITS_LABEL[product.unit]}あたり{product.unitPrice}円（税込）
-        </div>
-      </Paper>
-
-      <div class="mt-12">
-        <h2 class="font-bold text-3xl text-[#5A5A5A]">【商品説明】</h2>
-        <div class="text-xl mt-4">
-          {product.description}
-        </div>
-      </div>
-
-      <div class="flex justify-center">
-        <Button
-          class="mt-14 px-7 h-12"
-          color="secondary"
-          variant="raised"
-          on:click={$goto("../../reservation/new", { productId: $params.id })}
-        >
-          <p class="text-lg font-bold">予約手続きへ</p>
-        </Button>
-      </div>
+      {/if}
     </div>
   </div>
 {/await}
-
-<style lang="postcss">
-  .container {
-    @apply px-[70px] my-10;
-  }
-</style>

--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -70,9 +70,14 @@
           </div>
         </div>
       </div>
-      <h1 class="mt-3 text-2xl font-bold text-[#5A5A5A]">
+      <div class="mt-3 flex justify-between items-center">
+        <h1 class="text-2xl font-bold text-[#5A5A5A]">
         {product.name}
       </h1>
+        {#if isOutOfStock(product)}
+          <p class="text-[#ff0000] text-xl">終了</p>
+        {/if}
+      </div>
       <img
         src={product.image ??
           "./../../../public/images/default_product_image.png"}

--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -35,6 +35,10 @@
       return null;
     }
   }
+
+  function isOutOfStock(product: TProduct): boolean {
+    return product.remaining <= 0;
+  }
 </script>
 
 {#await fetchProduct()}
@@ -72,8 +76,8 @@
       </div>
       <div class="mt-3 flex justify-between items-center">
         <h1 class="text-2xl font-bold text-[#5A5A5A]">
-        {product.name}
-      </h1>
+          {product.name}
+        </h1>
         {#if isOutOfStock(product)}
           <p class="text-[#ff0000] text-xl">終了</p>
         {/if}
@@ -110,17 +114,8 @@
       </div>
     </Paper>
 
-    <div class="flex justify-center grid gap-4">
-      <Button
-        color="secondary"
-        variant="raised"
-        class="w-[150px] px-4 py-2 mt-10 mr-4 rounded-full"
-        on:click={() => $goto("../../../product/")}
-        type="button"
-      >
-        <p class="black">キャンセル</p>
-      </Button>
-      {#if $profile.attribute === USER_ATTRIBUTE.consumer}
+    {#if $profile.attribute === USER_ATTRIBUTE.consumer && !isOutOfStock(product)}
+      <div class="flex justify-center">
         <Button
           variant="raised"
           class="w-[150px] px-4 py-2 mt-10 rounded-full"
@@ -129,7 +124,7 @@
         >
           <p class="black">予約</p>
         </Button>
-      {/if}
-    </div>
+      </div>
+    {/if}
   </div>
 {/await}

--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -41,23 +41,23 @@
   <div class="flex justify-center">
     <CircularProgress style="height: 160px; width: 32px;" indeterminate />
   </div>
-{:then productData}
+{:then product}
   <div class="grid justify-center">
     <div class="container">
       <div class="flex">
-        {#if productData.producer.image}
+        {#if product.producer.image}
           <img
             class="w-[40px] h-[40px] rounded-[50%]"
-            src={productData.producer.image}
+            src={product.producer.image}
             alt=""
           />
-        {:else if productData.producer.classification === "individual"}
+        {:else if product.producer.classification === "individual"}
           <img
             class="w-[40px] h-[40px] rounded-[50%]"
             src="./../../../public/images/farmer.png"
             alt=""
           />
-        {:else if productData.producer.classification === "corporate"}
+        {:else if product.producer.classification === "corporate"}
           <img
             class="w-[40px] h-[40px] rounded-[50%]"
             src="./../../../public/images/house.png"
@@ -66,15 +66,15 @@
         {/if}
         <div class="ml-4 mt-3">
           <div class="text-xl text-[#8A8A8A]">
-            {productData.producer.name}
+            {product.producer.name}
           </div>
         </div>
       </div>
       <h1 class="mt-3 text-2xl font-bold text-[#5A5A5A]">
-        {productData.name}
+        {product.name}
       </h1>
       <img
-        src={productData.image ??
+        src={product.image ??
           "./../../../public/images/default_product_image.png"}
         alt=""
         width="300"
@@ -84,28 +84,28 @@
 
     <Paper class="mt-3 w-[300px]" color="secondary" variant="outlined">
       <p>
-        {productData.description}
+        {product.description}
       </p>
     </Paper>
 
     <Paper class="mt-3 w-[300px]" color="secondary" variant="outlined">
       <div class="text-center text-base text-[#5A5A5A] mt-2">
-        {productData.unitQuantity}{CROP_UNITS_LABEL[
-          productData.unit
-        ]}あたり{productData.unitPrice}円
+        {product.unitQuantity}{CROP_UNITS_LABEL[
+          product.unit
+        ]}あたり{product.unitPrice}円
       </div>
       <div class="text-center text-base text-[#5A5A5A] mt-2">
-        残りあと{productData.remaining}点
+        残りあと{product.remaining}点
       </div>
       <div class="text-center text-base text-[#5A5A5A] mt-2">
         予約期間：
-        {dayjs(productData.startAt).format("MM/DD HH:mm")}
+        {dayjs(product.startAt).format("MM/DD HH:mm")}
         -
-        {dayjs(productData.endAt).format("MM/DD HH:mm")}
+        {dayjs(product.endAt).format("MM/DD HH:mm")}
       </div>
     </Paper>
 
-    <div class="flex justify-center">
+    <div class="flex justify-center grid gap-4">
       <Button
         color="secondary"
         variant="raised"
@@ -116,16 +116,14 @@
         <p class="black">キャンセル</p>
       </Button>
       {#if $profile.attribute === USER_ATTRIBUTE.consumer}
-        <div class="flex justify-center">
-          <Button
-            variant="raised"
-            class="w-[150px] px-4 py-2 mt-10 rounded-full"
-            color="secondary"
-            on:click={$goto("../../reservation/new", { productId: $params.id })}
-          >
-            <p class="black">予約</p>
-          </Button>
-        </div>
+        <Button
+          variant="raised"
+          class="w-[150px] px-4 py-2 mt-10 rounded-full"
+          color="secondary"
+          on:click={$goto("../../reservation/new", { productId: $params.id })}
+        >
+          <p class="black">予約</p>
+        </Button>
       {/if}
     </div>
   </div>


### PR DESCRIPTION
## 作業内容
- 要件定義書に合わせてデザイン調整（予約画面に合わせて実装しました）
- 予約ボタンは作物の在庫がある場合＆消費者アカウントのみ表示させるように修正

## 実装結果
![Screen Shot 2023-06-28 at 21 27 40](https://github.com/NS-APU/BabaCafe/assets/54695442/bf94d9f6-228c-4735-858e-41fd4b9d3224)

在庫切れの場合は以下のように終了ラベルを表示し、予約ボタンを除去して予約ができないようにしております。
![Screen Shot 2023-06-28 at 21 26 00](https://github.com/NS-APU/BabaCafe/assets/54695442/e390b406-4ff9-4f79-9b4f-4303b045c0a3)