### PR TITLE
予約取り消し機能の実装

### DIFF
--- a/server/app/src/reservation/reservation.controller.ts
+++ b/server/app/src/reservation/reservation.controller.ts
@@ -55,4 +55,12 @@ export class ReservationController {
   ): Promise<TReservation> {
     return this.reservationService.updateReservationForReceived(account, reservationId);
   }
+
+  @Put('/products/:reservationId/canceled')
+  async updateReservationForCanceled(
+    @GetAccount() account: Account,
+    @Param('reservationId') reservationId: string,
+  ): Promise<TReservation> {
+    return this.reservationService.updateReservationForCanceled(account, reservationId);
+  }
 }

--- a/web/app/src/models/Reservation.ts
+++ b/web/app/src/models/Reservation.ts
@@ -70,4 +70,11 @@ export class ReservationRepository {
       method: 'PUT',
     });
   }
+
+  async canceled(id: string): Promise<TReservation> {
+    return await baseAPI<TReservation>({
+      endpoint: `${this.baseEndpoint}/products/${id}/canceled`,
+      method: 'PUT',
+    });
+  }
 }

--- a/web/app/src/models/Reservation.ts
+++ b/web/app/src/models/Reservation.ts
@@ -9,7 +9,7 @@ export type TReservationForm = Jsonify<CreateReservationDto>;
 export type TReservationPackedForm = Jsonify<UpdateReservationForPackedDto>;
 
 export const statusToText: Record<TReservation['status'], string> = {
-  canceled: 'キャンセル',
+  canceled: '予約取り消し',
   packking: '出荷準備中',
   shipping: '配送中',
   keeping: '店舗保管中',

--- a/web/app/src/pages/reservation/[id]/index.svelte
+++ b/web/app/src/pages/reservation/[id]/index.svelte
@@ -30,20 +30,19 @@
     }
   }
 
-  $: isShowPackedButton = (reservation) => {
+  $: canPacked = (reservation) => {
     return RESERVATION_STATUS.packking === reservationStatus && reservation.product.producerId === $profile.id;
   };
 
-  $: isShowKeptButton = (reservation) => {
+  $: canKept = (reservation) => {
     return RESERVATION_STATUS.shipping === reservationStatus && reservation.receiveLocationId === $profile.id;
   };
 
-  $: isShowReceivedButton = (reservation) => {
+  $: canReceived = (reservation) => {
     return RESERVATION_STATUS.keeping === reservationStatus && reservation.consumerId === $profile.id;
   };
 
-  // TODO:編集と取り消しの条件が同じなのでまとめたい（変数名が思いつかなかったので保留）
-  $: isShowCanceledButton = (reservation) => {
+  $: canEdit = (reservation) => {
     return RESERVATION_STATUS.packking === reservationStatus && reservation.consumerId === $profile.id;
   };
 
@@ -250,7 +249,7 @@
       </Paper>
     </div>
     <div class="mt-3 grid justify-center p-3">
-      {#if isShowPackedButton(reservationData)}
+      {#if canPacked(reservationData)}
         <Button
           class="w-[150px]  rounded-full px-4 py-2"
           color="secondary"
@@ -297,7 +296,7 @@
           </Actions>
         </Dialog>
       {/if}
-      {#if isShowKeptButton(reservationData)}
+      {#if canKept(reservationData)}
         <Button
           class="w-[150px]  rounded-full px-4 py-2"
           color="secondary"
@@ -318,7 +317,7 @@
           </Actions>
         </Dialog>
       {/if}
-      {#if isShowReceivedButton(reservationData)}
+      {#if canReceived(reservationData)}
         <Button
           class="w-[150px]  rounded-full px-4 py-2"
           color="secondary"
@@ -339,7 +338,7 @@
           </Actions>
         </Dialog>
       {/if}
-      {#if isShowCanceledButton(reservationData)}
+      {#if canEdit(reservationData)}
         <div>
           <Button class="  mr-2 w-[150px] rounded-full px-4 py-2" color="secondary" variant="raised">
             <!-- TODO:編集ページに遷移 -->

--- a/web/app/src/pages/reservation/[id]/index.svelte
+++ b/web/app/src/pages/reservation/[id]/index.svelte
@@ -125,7 +125,7 @@
       const updateReservationData = await reservationRepository.canceled($params.id);
       reservationStatus = updateReservationData.status;
       addToast({
-        message: '予約をキャンセルしました。',
+        message: '予約を取り消しました。',
       });
     } catch (err) {
       handleError(err);
@@ -340,10 +340,10 @@
       {/if}
       {#if canEdit(reservationData)}
         <div>
+          <!-- TODO:ボタン配置しただけなので要ページ遷移処理。
           <Button class="  mr-2 w-[150px] rounded-full px-4 py-2" color="secondary" variant="raised">
-            <!-- TODO:編集ページに遷移 -->
             <p class="text-lg font-bold">編集</p>
-          </Button>
+          </Button> -->
 
           <Button
             class="w-[150px] rounded-full px-4 py-2"

--- a/web/app/src/pages/reservation/[id]/index.svelte
+++ b/web/app/src/pages/reservation/[id]/index.svelte
@@ -75,6 +75,9 @@
       case 'received':
         await received();
         break;
+      case 'canceled':
+        await canceled();
+        break;
       default:
         // NOP
         break;
@@ -118,7 +121,15 @@
   }
 
   async function canceled() {
-    //TODO:削除APIを使用する
+    try {
+      const updateReservationData = await reservationRepository.canceled($params.id);
+      reservationStatus = updateReservationData.status;
+      addToast({
+        message: '予約をキャンセルしました。',
+      });
+    } catch (err) {
+      handleError(err);
+    }
   }
 
   function handleError(err) {
@@ -342,7 +353,7 @@
             <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="outlined">
               <p class="text-lg font-bold">キャンセル</p>
             </Button>
-            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="raised" action="received">
+            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="raised" action="canceled">
               <p class="text-lg font-bold">取り消し</p>
             </Button>
           </Actions>

--- a/web/app/src/pages/reservation/[id]/index.svelte
+++ b/web/app/src/pages/reservation/[id]/index.svelte
@@ -42,6 +42,7 @@
     return RESERVATION_STATUS.keeping === reservationStatus && reservation.consumerId === $profile.id;
   };
 
+  // TODO:編集と取り消しの条件が同じなのでまとめたい（変数名が思いつかなかったので保留）
   $: isShowCanceledButton = (reservation) => {
     return RESERVATION_STATUS.packking === reservationStatus && reservation.consumerId === $profile.id;
   };
@@ -74,6 +75,9 @@
         break;
       case 'received':
         await received();
+        break;
+      case 'canceled':
+        await canceled();
         break;
       default:
         // NOP
@@ -328,25 +332,32 @@
         </Dialog>
       {/if}
       {#if isShowCanceledButton(reservationData)}
-        <Button
-          class="w-[150px]  rounded-full px-4 py-2"
-          color="secondary"
-          variant="raised"
-          on:click={() => (isOpenCanceledConfirmDialog = true)}
-        >
-          <p class="text-lg font-bold">予約取り消し</p>
-        </Button>
-        <Dialog selection bind:open={isOpenCanceledConfirmDialog} on:SMUIDialog:closed={onDialogClosedHandle}>
-          <Title>予約を取り消しますか？</Title>
-          <Actions>
-            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="outlined">
-              <p class="text-lg font-bold">キャンセル</p>
-            </Button>
-            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="raised" action="received">
-              <p class="text-lg font-bold">取り消し</p>
-            </Button>
-          </Actions>
-        </Dialog>
+        <div>
+          <Button class="  mr-2 w-[150px] rounded-full px-4 py-2" color="secondary" variant="raised">
+            <!-- TODO:編集ページに遷移 -->
+            <p class="text-lg font-bold">編集</p>
+          </Button>
+
+          <Button
+            class="w-[150px] rounded-full px-4 py-2"
+            color="secondary"
+            variant="raised"
+            on:click={() => (isOpenCanceledConfirmDialog = true)}
+          >
+            <p class="text-lg font-bold">予約取り消し</p>
+          </Button>
+          <Dialog selection bind:open={isOpenCanceledConfirmDialog} on:SMUIDialog:closed={onDialogClosedHandle}>
+            <Title>予約を取り消しますか？</Title>
+            <Actions>
+              <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="outlined">
+                <p class="text-lg font-bold">キャンセル</p>
+              </Button>
+              <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="raised" action="canceled">
+                <p class="text-lg font-bold">取り消し</p>
+              </Button>
+            </Actions>
+          </Dialog>
+        </div>
       {/if}
     </div>
   </div>

--- a/web/app/src/pages/reservation/[id]/index.svelte
+++ b/web/app/src/pages/reservation/[id]/index.svelte
@@ -42,9 +42,14 @@
     return RESERVATION_STATUS.keeping === reservationStatus && reservation.consumerId === $profile.id;
   };
 
+  $: isShowCanceledButton = (reservation) => {
+    return RESERVATION_STATUS.packking === reservationStatus && reservation.consumerId === $profile.id;
+  };
+
   let isOpenPackedConfirmDialog = false;
   let isOpenKeptConfirmDialog = false;
   let isOpenReceivedConfirmDialog = false;
+  let isOpenCanceledConfirmDialog = false;
 
   let selectedShipperId = '';
 
@@ -110,6 +115,10 @@
     } catch (err) {
       handleError(err);
     }
+  }
+
+  async function canceled() {
+    //TODO:削除APIを使用する
   }
 
   function handleError(err) {
@@ -314,6 +323,27 @@
             </Button>
             <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="raised" action="received">
               <p class="text-lg font-bold">受取り</p>
+            </Button>
+          </Actions>
+        </Dialog>
+      {/if}
+      {#if isShowCanceledButton(reservationData)}
+        <Button
+          class="w-[150px]  rounded-full px-4 py-2"
+          color="secondary"
+          variant="raised"
+          on:click={() => (isOpenCanceledConfirmDialog = true)}
+        >
+          <p class="text-lg font-bold">予約取り消し</p>
+        </Button>
+        <Dialog selection bind:open={isOpenCanceledConfirmDialog} on:SMUIDialog:closed={onDialogClosedHandle}>
+          <Title>予約を取り消しますか？</Title>
+          <Actions>
+            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="outlined">
+              <p class="text-lg font-bold">キャンセル</p>
+            </Button>
+            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="raised" action="received">
+              <p class="text-lg font-bold">取り消し</p>
             </Button>
           </Actions>
         </Dialog>


### PR DESCRIPTION
# 概要

予約詳細画面への予約取り消しボタンの追加と、ステータス変更機能の実装

# 変更点
  
* (web)

  * 取り消しボタンの実装
  * バックエンド側実装のAPI呼び出し
  * 編集ボタンの実装(制約あり)

* (back)

  * PUT /reservations/products/:reservationId/canceled API新規作成
    * 出品残量の更新
    * ステータス変更 pakking -> canceled

# 制約

編集ボタンはボタン配置のみの実装で、編集機能は未実装。