### PR TITLE
出品周りのアクセス制御を修正

### DIFF
--- a/server/app/src/product/product.controller.ts
+++ b/server/app/src/product/product.controller.ts
@@ -11,8 +11,8 @@ export class ProductController {
   constructor(private readonly productService: ProductService) {}
 
   @Get()
-  async getProducts() {
-    return this.productService.getProducts();
+  async getProducts(@GetAccount() account: Account) {
+    return this.productService.getProducts(account);
   }
 
   @Get('/:productId')

--- a/server/app/src/product/product.service.ts
+++ b/server/app/src/product/product.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as dayjs from 'dayjs';
 import { Account, USER_ATTRIBUTE } from 'src/account/entities/account.entity';
-import { Repository } from 'typeorm';
+import { Repository, FindOptionsWhere } from 'typeorm';
 import { CreateProductDto } from './dto/create-product.dto';
 import { Product, TProduct } from './entities/product.entity';
 
@@ -15,9 +15,17 @@ export class ProductService {
     private accountRepository: Repository<Account>,
   ) {}
 
-  async getProducts(): Promise<TProduct[]> {
+  async getProducts(account: Account): Promise<TProduct[]> {
+    let where: FindOptionsWhere<Product> = {};
+    if (account.attribute === USER_ATTRIBUTE.producer) {
+      where = {
+        producer: {
+          id: account.id,
+        },
+      };
+    }
     return await this.productRepository
-      .find({ relations: { producer: true }, order: { id: 'ASC' } })
+      .find({ where, relations: { producer: true }, order: { id: 'ASC' } })
       .then((products) => products.map((product) => product.convertTProduct()));
   }
 

--- a/web/app/src/components/organizms/Sidebar.svelte
+++ b/web/app/src/components/organizms/Sidebar.svelte
@@ -2,6 +2,8 @@
   import { goto } from '@roxi/routify';
   import Drawer, { Content } from '@smui/drawer';
   import List, { Item, Text, Separator } from '@smui/list';
+  import { USER_ATTRIBUTE } from '../../constants/account';
+  import { profile } from '../../stores/Account';
   import { isLoggedIn, markAsLogoutState } from '../../stores/Login';
   import { addToast } from '../../stores/Toast';
 
@@ -41,9 +43,11 @@
       <Item href="javascript:void(0)" on:click={() => setActive('reservation')} activated={active === 'reservation'}>
         <Text class="text-base">予約一覧</Text>
       </Item>
-      <Item href="javascript:void(0)" on:click={() => setActive('product')} activated={active === 'product'}>
-        <Text class="text-base">出品一覧</Text>
-      </Item>
+      {#if [USER_ATTRIBUTE.producer, USER_ATTRIBUTE.consumer].includes($profile.attribute)}
+        <Item href="javascript:void(0)" on:click={() => setActive('product')} activated={active === 'product'}>
+          <Text class="text-base">出品一覧</Text>
+        </Item>
+      {/if}
       <!--
       <Item
         href="javascript:void(0)"

--- a/web/app/src/components/organizms/Sidebar.svelte
+++ b/web/app/src/components/organizms/Sidebar.svelte
@@ -43,7 +43,7 @@
       <Item href="javascript:void(0)" on:click={() => setActive('reservation')} activated={active === 'reservation'}>
         <Text class="text-base">予約一覧</Text>
       </Item>
-      {#if [USER_ATTRIBUTE.producer, USER_ATTRIBUTE.consumer].includes($profile.attribute)}
+      {#if [USER_ATTRIBUTE.producer, USER_ATTRIBUTE.consumer].includes($profile?.attribute)}
         <Item href="javascript:void(0)" on:click={() => setActive('product')} activated={active === 'product'}>
           <Text class="text-base">出品一覧</Text>
         </Item>


### PR DESCRIPTION
# 概要

出品周りのアクセス制御を修正

# 変更点
  
* (server)

  * 生産者の場合に出品一覧は自身の出品のみとなるようにした

* (web)

  * 出品一覧は消費者と生産者のみ表示するようにした

# 確認内容

* 生産者の場合に出品一覧が自身の出品のみ表示されていることを確認
* 消費者の場合に出品一覧がすべての生産者の出品が表示されていることを確認
* 物流業者の場合に出品一覧がサイドメニューに表示されていないことを確認
* 引渡し業者の場合に出品一覧がサイドメニューに表示されていないことを確認