### PR TITLE
サイドメニューに物流設定を追加して各ロールに合わせたダミー画面を表示できる

### DIFF
--- a/web/app/src/components/organizms/Sidebar.svelte
+++ b/web/app/src/components/organizms/Sidebar.svelte
@@ -48,6 +48,15 @@
           <Text class="text-base">出品一覧</Text>
         </Item>
       {/if}
+      {#if [USER_ATTRIBUTE.producer, USER_ATTRIBUTE.logistics, USER_ATTRIBUTE.intermediary].includes($profile?.attribute)}
+        <Item
+          href="javascript:void(0)"
+          on:click={() => setActive('logistics/setting')}
+          activated={active === 'logistics/setting'}
+        >
+          <Text class="text-base">物流設定</Text>
+        </Item>
+      {/if}
       <!--
       <Item
         href="javascript:void(0)"

--- a/web/app/src/pages/logistics/setting/_components/IntermediarySettingForm.svelte
+++ b/web/app/src/pages/logistics/setting/_components/IntermediarySettingForm.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+</script>
+
+<div>
+  <p class="text-base">引渡し業者向け物流設定</p>
+</div>

--- a/web/app/src/pages/logistics/setting/_components/LogisticsSettingForm.svelte
+++ b/web/app/src/pages/logistics/setting/_components/LogisticsSettingForm.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+</script>
+
+<div>
+  <p class="text-base">物流業者向け物流設定</p>
+</div>

--- a/web/app/src/pages/logistics/setting/_components/ProducerSettingForm.svelte
+++ b/web/app/src/pages/logistics/setting/_components/ProducerSettingForm.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+</script>
+
+<div>
+  <p class="text-base">生産者向け物流設定</p>
+</div>

--- a/web/app/src/pages/logistics/setting/index.svelte
+++ b/web/app/src/pages/logistics/setting/index.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { goto } from '@roxi/routify';
+  import { onMount } from 'svelte';
+  import { USER_ATTRIBUTE } from '../../../constants/account';
+  import { profile } from '../../../stores/Account';
+  import IntermediarySettingForm from './_components/IntermediarySettingForm.svelte';
+  import LogisticsSettingForm from './_components/LogisticsSettingForm.svelte';
+  import ProducerSettingForm from './_components/ProducerSettingForm.svelte';
+  onMount(() => {
+    if (
+      ![USER_ATTRIBUTE.producer, USER_ATTRIBUTE.logistics, USER_ATTRIBUTE.intermediary].includes($profile?.attribute)
+    ) {
+      $goto('/reservation');
+    }
+  });
+</script>
+
+<div>
+  {#if USER_ATTRIBUTE.producer === $profile?.attribute}
+    <ProducerSettingForm />
+  {/if}
+  {#if USER_ATTRIBUTE.logistics === $profile?.attribute}
+    <LogisticsSettingForm />
+  {/if}
+  {#if USER_ATTRIBUTE.intermediary === $profile?.attribute}
+    <IntermediarySettingForm />
+  {/if}
+</div>


### PR DESCRIPTION
# 概要

サイドメニューに物流設定を追加して各ロールに合わせたダミー画面を表示できるように対応

# 変更点
  
* 生産者、物流業者、引渡し業者の場合に、物流設定のメニューを追加して、各ロールに合わせたダミーの物流設定画面を開けるようにした
* 消費者がURL直打ちなどで物流設定画面を開こうとしても、物流設定画面を開かずに予約一覧を開くようにした

# 確認内容

* 生産者の場合にサイドメニューに物流設定が表示されており、クリックするとダミーの生産者用の物流設定画面が表示される
* 消費者の場合にURL直打ちで物流設定画面を開こうとした場合は予約一覧画面に遷移する
* 物流業者の場合にサイドメニューに物流設定が表示されており、クリックするとダミーの物流業者用の物流設定画面が表示される
* 引渡し業者の場合にサイドメニューに物流設定が表示されており、クリックするとダミーの引渡し業者用の物流設定画面が表示される