### PR TITLE
出品とりやめ機能の実装

### DIFF
--- a/server/app/src/product/product.controller.ts
+++ b/server/app/src/product/product.controller.ts
@@ -27,7 +27,7 @@ export class ProductController {
     return this.productService.createProduct(createProductDto, account);
   }
 
-  @Delete('/:productId/canceled')
+  @Delete('/:productId')
   async cancelProduct(@GetAccount() account: Account, @Param('productId') productId: string): Promise<TProduct> {
     return this.productService.cancelProduct(account, productId);
   }

--- a/server/app/src/product/product.controller.ts
+++ b/server/app/src/product/product.controller.ts
@@ -28,7 +28,7 @@ export class ProductController {
   }
 
   @Delete('/:productId')
-  async cancelProduct(@GetAccount() account: Account, @Param('productId') productId: string): Promise<TProduct> {
-    return this.productService.cancelProduct(account, productId);
+  async deleteProduct(@GetAccount() account: Account, @Param('productId') productId: string): Promise<TProduct> {
+    return this.productService.deleteProduct(account, productId);
   }
 }

--- a/server/app/src/product/product.controller.ts
+++ b/server/app/src/product/product.controller.ts
@@ -28,10 +28,7 @@ export class ProductController {
   }
 
   @Delete('/:productId/canceled')
-  async updateProductForCanceled(
-    @GetAccount() account: Account,
-    @Param('productId') productId: string,
-  ): Promise<TProduct> {
-    return this.productService.updateProductForCanceled(account, productId);
+  async cancelProduct(@GetAccount() account: Account, @Param('productId') productId: string): Promise<TProduct> {
+    return this.productService.cancelProduct(account, productId);
   }
 }

--- a/server/app/src/product/product.controller.ts
+++ b/server/app/src/product/product.controller.ts
@@ -1,8 +1,9 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, UseGuards, Delete } from '@nestjs/common';
 import { Account } from 'src/account/entities/account.entity';
 import { GetAccount } from 'src/account/get-account.decorator';
 import { JwtAuthGuard } from 'src/account/jwt-auth.guard';
 import { CreateProductDto } from './dto/create-product.dto';
+import { TProduct } from './entities/product.entity';
 import { ProductService } from './product.service';
 
 @Controller('products')
@@ -24,5 +25,13 @@ export class ProductController {
   @HttpCode(HttpStatus.CREATED)
   createProduct(@Body() createProductDto: CreateProductDto, @GetAccount() account: Account) {
     return this.productService.createProduct(createProductDto, account);
+  }
+
+  @Delete('/:productId/canceled')
+  async updateProductForCanceled(
+    @GetAccount() account: Account,
+    @Param('productId') productId: string,
+  ): Promise<TProduct> {
+    return this.productService.updateProductForCanceled(account, productId);
   }
 }

--- a/server/app/src/product/product.service.ts
+++ b/server/app/src/product/product.service.ts
@@ -31,7 +31,7 @@ export class ProductService {
 
   async getProduct(id: string): Promise<TProduct> {
     return await this.productRepository
-      .findOne({ where: { id }, relations: { producer: true } })
+      .findOne({ where: { id }, relations: { producer: true, reservations: true } })
       .then((product) => product.convertTProduct());
   }
 
@@ -72,17 +72,14 @@ export class ProductService {
     product.remaining = dto.quantity;
   }
 
-  async updateProductForCanceled(account: Account, productId: string): Promise<TProduct> {
+  async cancelProduct(account: Account, productId: string): Promise<TProduct> {
     const product = await this.productRepository.findOne({ where: { id: productId } });
 
-    if (!product) {
-      throw new BadRequestException();
-    }
-    if (account.id !== product.producerId) {
+    if (!product || account.id !== product.producerId) {
       throw new BadRequestException();
     }
 
-    this.productRepository.softRemove(product);
+    await this.productRepository.softRemove(product);
 
     return product.convertTProduct();
   }

--- a/server/app/src/product/product.service.ts
+++ b/server/app/src/product/product.service.ts
@@ -72,7 +72,7 @@ export class ProductService {
     product.remaining = dto.quantity;
   }
 
-  async cancelProduct(account: Account, productId: string): Promise<TProduct> {
+  async deleteProduct(account: Account, productId: string): Promise<TProduct> {
     const product = await this.productRepository.findOne({ where: { id: productId } });
 
     if (!product || account.id !== product.producerId) {

--- a/server/app/src/product/product.service.ts
+++ b/server/app/src/product/product.service.ts
@@ -63,4 +63,19 @@ export class ProductService {
     product.quantity = dto.quantity;
     product.remaining = dto.quantity;
   }
+
+  async updateProductForCanceled(account: Account, productId: string): Promise<TProduct> {
+    const product = await this.productRepository.findOne({ where: { id: productId } });
+
+    if (!product) {
+      throw new BadRequestException();
+    }
+    if (account.id !== product.producerId) {
+      throw new BadRequestException();
+    }
+
+    this.productRepository.softRemove(product);
+
+    return product.convertTProduct();
+  }
 }

--- a/web/app/src/models/Product.ts
+++ b/web/app/src/models/Product.ts
@@ -28,4 +28,11 @@ export class ProductRepository {
       body,
     });
   }
+
+  async canceled(id: string): Promise<TProduct> {
+    return await baseAPI<TProduct>({
+      endpoint: `${this.baseEndpoint}/${id}/canceled`,
+      method: 'DELETE',
+    });
+  }
 }

--- a/web/app/src/models/Product.ts
+++ b/web/app/src/models/Product.ts
@@ -31,7 +31,7 @@ export class ProductRepository {
 
   async canceled(id: string): Promise<TProduct> {
     return await baseAPI<TProduct>({
-      endpoint: `${this.baseEndpoint}/${id}/canceled`,
+      endpoint: `${this.baseEndpoint}/${id}`,
       method: 'DELETE',
     });
   }

--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -8,7 +8,7 @@
   import { USER_ATTRIBUTE } from '../../../constants/account';
   import { CROP_UNITS_LABEL } from '../../../constants/product';
   import { ProductRepository, type TProduct } from '../../../models/Product';
-  import { ReservationRepository, RESERVATION_STATUS } from '../../../models/Reservation';
+  import { ReservationRepository } from '../../../models/Reservation';
   import { profile } from '../../../stores/Account';
   import { markAsLogoutState } from '../../../stores/Login';
   import { addToast } from '../../../stores/Toast';
@@ -79,12 +79,7 @@
   let isOpenCanceledConfirmDialog = false;
 
   async function updateCancelButtonVisibility(product: TProduct) {
-    const result = (await reservationRepository.allReservations()).some(
-      (v) =>
-        v.productId === product.id &&
-        v.status !== RESERVATION_STATUS.completed &&
-        v.status !== RESERVATION_STATUS.canceled,
-    );
+    const result = (await reservationRepository.allReservations()).some((v) => v.productId === product.id);
     cancelButtonVisibility = !result;
   }
 

--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -22,7 +22,7 @@
       canCanceled = product.reservations.length === 0;
       return product;
     } catch (err) {
-      handleError(err, '');
+      handleError(err, '商品の取得');
       return null;
     }
   }
@@ -68,7 +68,7 @@
         break;
       default:
         addToast({
-          message: '商品の取得に失敗しました。もう一度時間をおいて再読み込みしてください。',
+          message: `${operation}に失敗しました。もう一度時間をおいて再読み込みしてください。`,
           type: 'error',
         });
         break;

--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -2,37 +2,90 @@
   import { goto, params } from '@roxi/routify';
   import Button from '@smui/button';
   import CircularProgress from '@smui/circular-progress';
+  import Dialog, { Title, Actions } from '@smui/dialog';
   import Paper from '@smui/paper';
   import dayjs from 'dayjs';
   import { USER_ATTRIBUTE } from '../../../constants/account';
   import { CROP_UNITS_LABEL } from '../../../constants/product';
   import { ProductRepository, type TProduct } from '../../../models/Product';
+  import { ReservationRepository, RESERVATION_STATUS } from '../../../models/Reservation';
   import { profile } from '../../../stores/Account';
   import { markAsLogoutState } from '../../../stores/Login';
   import { addToast } from '../../../stores/Toast';
 
+  $: productRepository = new ProductRepository();
+  $: reservationRepository = new ReservationRepository();
+
   async function fetchProduct(): Promise<TProduct> {
     try {
-      return await new ProductRepository().findOne($params.id);
+      const product = await productRepository.findOne($params.id);
+      updateCancelButtonVisibility(product);
+      return product;
     } catch (err) {
-      switch (err.error || err.message) {
-        case 'Unauthorized':
-          markAsLogoutState();
-          addToast({
-            message: '認証が切れました。再度ログインしてください。',
-            type: 'error',
-          });
-          $goto('/login');
-          break;
-        default:
-          addToast({
-            message: '商品の取得に失敗しました。もう一度時間をおいて再読み込みしてください。',
-            type: 'error',
-          });
-          break;
-      }
+      handleError(err);
       return null;
     }
+  }
+
+  async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
+    switch (e.detail.action) {
+      case 'canceled':
+        await canceled();
+        break;
+      default:
+        // NOP
+        break;
+    }
+  }
+
+  async function canceled() {
+    try {
+      await productRepository.canceled($params.id);
+      addToast({
+        message: '出品を取りやめました。',
+      });
+      $goto('/product');
+    } catch (err) {
+      handleError(err);
+    }
+  }
+
+  function handleError(err) {
+    switch (err.error || err.message) {
+      case 'Bad Request':
+        addToast({
+          message: '商品の更新に失敗しました。開発者へお問い合わせください。',
+          type: 'error',
+        });
+        break;
+      case 'Unauthorized':
+        markAsLogoutState();
+        addToast({
+          message: '認証が切れました。再度ログインしてください。',
+          type: 'error',
+        });
+        $goto('/login');
+        break;
+      default:
+        addToast({
+          message: '商品の取得に失敗しました。もう一度時間をおいて再読み込みしてください。',
+          type: 'error',
+        });
+        break;
+    }
+  }
+
+  let cancelButtonVisibility = false;
+  let isOpenCanceledConfirmDialog = false;
+
+  async function updateCancelButtonVisibility(product: TProduct) {
+    const result = (await reservationRepository.allReservations()).some(
+      (v) =>
+        v.productId === product.id &&
+        v.status !== RESERVATION_STATUS.completed &&
+        v.status !== RESERVATION_STATUS.canceled,
+    );
+    cancelButtonVisibility = !result;
   }
 
   function isOutOfStock(product: TProduct): boolean {
@@ -107,6 +160,30 @@
         >
           <p class="black">予約</p>
         </Button>
+      </div>
+    {/if}
+
+    {#if $profile.attribute === USER_ATTRIBUTE.producer && cancelButtonVisibility}
+      <div class="flex justify-center">
+        <Button
+          variant="raised"
+          class="mt-10 w-[150px] rounded-full px-4 py-2"
+          color="secondary"
+          on:click={() => (isOpenCanceledConfirmDialog = true)}
+        >
+          <p class="black">出品取りやめ</p>
+        </Button>
+        <Dialog selection bind:open={isOpenCanceledConfirmDialog} on:SMUIDialog:closed={onDialogClosedHandle}>
+          <Title>出品を取りやめますか？</Title>
+          <Actions>
+            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="outlined">
+              <p class="text-lg font-bold">キャンセル</p>
+            </Button>
+            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="raised" action="canceled">
+              <p class="text-lg font-bold">出品取りやめ</p>
+            </Button>
+          </Actions>
+        </Dialog>
       </div>
     {/if}
   </div>

--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -8,25 +8,21 @@
   import { USER_ATTRIBUTE } from '../../../constants/account';
   import { CROP_UNITS_LABEL } from '../../../constants/product';
   import { ProductRepository, type TProduct } from '../../../models/Product';
-  import { ReservationRepository } from '../../../models/Reservation';
   import { profile } from '../../../stores/Account';
   import { markAsLogoutState } from '../../../stores/Login';
   import { addToast } from '../../../stores/Toast';
 
   $: productRepository = new ProductRepository();
-  $: reservationRepository = new ReservationRepository();
   $: canCanceled = false;
   let isOpenCanceledConfirmDialog = false;
 
   async function fetchProduct(): Promise<TProduct> {
     try {
       const product = await productRepository.findOne($params.id);
-      canCanceled = !(await reservationRepository.allReservations()).some(
-        (reservation) => reservation.productId === product.id,
-      );
+      canCanceled = product.reservations.length === 0;
       return product;
     } catch (err) {
-      handleError(err);
+      handleError(err, '');
       return null;
     }
   }
@@ -50,15 +46,15 @@
       });
       $goto('/product');
     } catch (err) {
-      handleError(err);
+      handleError(err, '出品のとりやめ');
     }
   }
 
-  function handleError(err) {
+  function handleError(err, operation: string) {
     switch (err.error || err.message) {
       case 'Bad Request':
         addToast({
-          message: '商品の更新に失敗しました。開発者へお問い合わせください。',
+          message: `${operation}に失敗しました。開発者へお問い合わせください。`,
           type: 'error',
         });
         break;

--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -15,11 +15,15 @@
 
   $: productRepository = new ProductRepository();
   $: reservationRepository = new ReservationRepository();
+  $: canCanceled = false;
+  let isOpenCanceledConfirmDialog = false;
 
   async function fetchProduct(): Promise<TProduct> {
     try {
       const product = await productRepository.findOne($params.id);
-      updateCancelButtonVisibility(product);
+      canCanceled = !(await reservationRepository.allReservations()).some(
+        (reservation) => reservation.productId === product.id,
+      );
       return product;
     } catch (err) {
       handleError(err);
@@ -73,14 +77,6 @@
         });
         break;
     }
-  }
-
-  let cancelButtonVisibility = false;
-  let isOpenCanceledConfirmDialog = false;
-
-  async function updateCancelButtonVisibility(product: TProduct) {
-    const result = (await reservationRepository.allReservations()).some((v) => v.productId === product.id);
-    cancelButtonVisibility = !result;
   }
 
   function isOutOfStock(product: TProduct): boolean {
@@ -158,7 +154,7 @@
       </div>
     {/if}
 
-    {#if $profile.attribute === USER_ATTRIBUTE.producer && cancelButtonVisibility}
+    {#if $profile.attribute === USER_ATTRIBUTE.producer && canCanceled}
       <div class="flex justify-center">
         <Button
           variant="raised"

--- a/web/app/src/pages/reservation/index.svelte
+++ b/web/app/src/pages/reservation/index.svelte
@@ -64,21 +64,23 @@
       </Head>
       {#each items as item (item.id)}
         <Body class="cell">
-          <Row on:click={$goto(`./${item.id}`)}>
-            {#if $profile.attribute !== USER_ATTRIBUTE.producer}
-              <Cell class="text-center">{item.product.producer.name}</Cell>
-            {/if}
-            <Cell class="text-center">{item.product.name}</Cell>
-            <Cell class="text-center">{item.quantity}</Cell>
-            <Cell class="text-center">{item.totalPrice}円</Cell>
-            {#if $profile.attribute !== USER_ATTRIBUTE.consumer}
-              <Cell class="text-center">{item.consumer.name}</Cell>
-            {/if}
-            <Cell class="text-center">{dayjs(item.desiredAt).format('YYYY/MM/DD')}</Cell>
-            <Cell class="text-center">{item.receiveLocation.name}</Cell>
-            <Cell class="text-center">{item.shipper?.name ?? ''}</Cell>
-            <Cell class="text-center">{statusToText[item.status]}</Cell>
-          </Row>
+          {#if item.product !== null}
+            <Row on:click={$goto(`./${item.id}`)}>
+              {#if $profile.attribute !== USER_ATTRIBUTE.producer}
+                <Cell class="text-center">{item.product.producer.name}</Cell>
+              {/if}
+              <Cell class="text-center">{item.product.name}</Cell>
+              <Cell class="text-center">{item.quantity}</Cell>
+              <Cell class="text-center">{item.totalPrice}円</Cell>
+              {#if $profile.attribute !== USER_ATTRIBUTE.consumer}
+                <Cell class="text-center">{item.consumer.name}</Cell>
+              {/if}
+              <Cell class="text-center">{dayjs(item.desiredAt).format('YYYY/MM/DD')}</Cell>
+              <Cell class="text-center">{item.receiveLocation.name}</Cell>
+              <Cell class="text-center">{item.shipper?.name ?? ''}</Cell>
+              <Cell class="text-center">{statusToText[item.status]}</Cell>
+            </Row>
+          {/if}
         </Body>
       {/each}
     </DataTable>

--- a/web/app/src/pages/reservation/index.svelte
+++ b/web/app/src/pages/reservation/index.svelte
@@ -64,23 +64,21 @@
       </Head>
       {#each items as item (item.id)}
         <Body class="cell">
-          {#if item.product !== null}
-            <Row on:click={$goto(`./${item.id}`)}>
-              {#if $profile.attribute !== USER_ATTRIBUTE.producer}
-                <Cell class="text-center">{item.product.producer.name}</Cell>
-              {/if}
-              <Cell class="text-center">{item.product.name}</Cell>
-              <Cell class="text-center">{item.quantity}</Cell>
-              <Cell class="text-center">{item.totalPrice}円</Cell>
-              {#if $profile.attribute !== USER_ATTRIBUTE.consumer}
-                <Cell class="text-center">{item.consumer.name}</Cell>
-              {/if}
-              <Cell class="text-center">{dayjs(item.desiredAt).format('YYYY/MM/DD')}</Cell>
-              <Cell class="text-center">{item.receiveLocation.name}</Cell>
-              <Cell class="text-center">{item.shipper?.name ?? ''}</Cell>
-              <Cell class="text-center">{statusToText[item.status]}</Cell>
-            </Row>
-          {/if}
+          <Row on:click={$goto(`./${item.id}`)}>
+            {#if $profile.attribute !== USER_ATTRIBUTE.producer}
+              <Cell class="text-center">{item.product.producer.name}</Cell>
+            {/if}
+            <Cell class="text-center">{item.product.name}</Cell>
+            <Cell class="text-center">{item.quantity}</Cell>
+            <Cell class="text-center">{item.totalPrice}円</Cell>
+            {#if $profile.attribute !== USER_ATTRIBUTE.consumer}
+              <Cell class="text-center">{item.consumer.name}</Cell>
+            {/if}
+            <Cell class="text-center">{dayjs(item.desiredAt).format('YYYY/MM/DD')}</Cell>
+            <Cell class="text-center">{item.receiveLocation.name}</Cell>
+            <Cell class="text-center">{item.shipper?.name ?? ''}</Cell>
+            <Cell class="text-center">{statusToText[item.status]}</Cell>
+          </Row>
         </Body>
       {/each}
     </DataTable>


### PR DESCRIPTION
# 概要

出品とりやめボタンの追加と、論理削除の実装

# 変更点
  
* (web)

  * 出品とりやめボタンの実装
    * 予約が1回でもあった時点で表示しないように制御
  * 確認ダイアログの実装
  * バックエンド側実装のAPI呼び出し
  * エラーハンドリングをメソッドに変更（fetchProduct()とcanceled()からも呼べるようにするため）


* (back)

  * DELETE /products/:productId/canceled API新規作成
    * 論理削除の実行
  
# 動作確認内容
  * 出品とりやめボタンを押すことで、出品一覧からその出品物が削除されること
  * １度でもその出品物に対して予約が行われた場合、出品とりやめボタンが表示されないこと
   