### PR TITLE
引渡し業者向け物流設定の表示と設定ができる

### DIFF
--- a/server/app/src/app.module.ts
+++ b/server/app/src/app.module.ts
@@ -6,6 +6,7 @@ import { getMetadataArgsStorage } from 'typeorm';
 import { AccountModule } from './account/account.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { LogisticsModule } from './logistics/logistics.module';
 import { ProductModule } from './product/product.module';
 import { ReservationModule } from './reservation/reservation.module';
 dotenv.config();
@@ -30,6 +31,7 @@ dotenv.config();
     AccountModule,
     ProductModule,
     ReservationModule,
+    LogisticsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/server/app/src/logistics/logistics.controller.ts
+++ b/server/app/src/logistics/logistics.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Get, Put, Param, UseGuards } from '@nestjs/common';
+import { Account } from 'src/account/entities/account.entity';
+import { GetAccount } from 'src/account/get-account.decorator';
+import { JwtAuthGuard } from 'src/account/jwt-auth.guard';
+import { CreateLogisticsSettingForIntermediaryDto } from 'src/logistics/setting/intermediary/dto/create-setting.dto';
+import { LogisticsService } from './logistics.service';
+
+@Controller('logistics')
+@UseGuards(JwtAuthGuard)
+export class LogisticsController {
+  constructor(private readonly logisticService: LogisticsService) {}
+
+  @Get('/setting/logistics/:logisticsId')
+  async getLogisticsSetting(@Param('logisticsId') logisticsId: string) {
+    return this.logisticService.getLogisticsSetting(logisticsId);
+  }
+
+  @Get('/setting/intermediary/:intermediaryId')
+  async getIntermediarySetting(@Param('intermediaryId') intermediaryId: string) {
+    return this.logisticService.getIntermediarySetting(intermediaryId);
+  }
+
+  @Put('/setting/intermediary/:intermediaryId')
+  async updateIntermediarySetting(
+    @Param('intermediaryId') intermediaryId: string,
+    @Body() dto: CreateLogisticsSettingForIntermediaryDto,
+    @GetAccount() account: Account,
+  ) {
+    return this.logisticService.updateIntermediarySetting(account, intermediaryId, dto);
+  }
+}

--- a/server/app/src/logistics/logistics.module.ts
+++ b/server/app/src/logistics/logistics.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Account } from 'src/account/entities/account.entity';
+import { LogisticsController } from './logistics.controller';
+import { LogisticsService } from './logistics.service';
+import { LogisticsSettingForIntermediary } from './setting/intermediary/entities/setting.entity';
+import { LogisticsSettingForLogistics } from './setting/logistics/entities/setting.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([LogisticsSettingForLogistics, LogisticsSettingForIntermediary, Account])],
+  controllers: [LogisticsController],
+  providers: [LogisticsService],
+  exports: [LogisticsService],
+})
+export class LogisticsModule {}

--- a/server/app/src/logistics/logistics.service.ts
+++ b/server/app/src/logistics/logistics.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Account } from 'src/account/entities/account.entity';
+import { CreateLogisticsSettingForIntermediaryDto } from 'src/logistics/setting/intermediary/dto/create-setting.dto';
+import { LogisticsSettingForIntermediary } from 'src/logistics/setting/intermediary/entities/setting.entity';
+import { LogisticsSettingForLogistics } from 'src/logistics/setting/logistics/entities/setting.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class LogisticsService {
+  constructor(
+    @InjectRepository(LogisticsSettingForLogistics)
+    private logisticsSettingRepository: Repository<LogisticsSettingForLogistics>,
+    @InjectRepository(LogisticsSettingForIntermediary)
+    private intermediarySettingRepository: Repository<LogisticsSettingForIntermediary>,
+  ) {}
+
+  async getLogisticsSetting(logisticsId: string): Promise<LogisticsSettingForLogistics> {
+    return await this.logisticsSettingRepository
+      .findOne({ where: { logisticsId }, relations: ['routes', 'routes.trips', 'routes.trips.timetables'] })
+      .then((setting) => setting);
+  }
+
+  async getIntermediarySetting(intermediaryId: string): Promise<LogisticsSettingForIntermediary> {
+    return await this.intermediarySettingRepository.findOne({ where: { intermediaryId } }).then((setting) => setting);
+  }
+
+  async updateIntermediarySetting(
+    account: Account,
+    intermediaryId: string,
+    dto: CreateLogisticsSettingForIntermediaryDto,
+  ): Promise<LogisticsSettingForIntermediary> {
+    const setting = await this.intermediarySettingRepository
+      .findOne({
+        where: { intermediaryId },
+      })
+      .then((setting) => setting);
+
+    if (!setting) {
+      throw new BadRequestException();
+    }
+    if (setting.intermediaryId !== account.id) {
+      throw new BadRequestException();
+    }
+
+    setting.stop = dto.stop;
+    this.intermediarySettingRepository.save(setting);
+    return setting;
+  }
+}

--- a/server/app/src/logistics/setting/intermediary/dto/create-setting.dto.ts
+++ b/server/app/src/logistics/setting/intermediary/dto/create-setting.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class CreateLogisticsSettingForIntermediaryDto {
+  @IsNotEmpty()
+  @IsString()
+  stop: string;
+}

--- a/server/app/src/logistics/setting/intermediary/entities/setting.entity.ts
+++ b/server/app/src/logistics/setting/intermediary/entities/setting.entity.ts
@@ -22,3 +22,8 @@ export class LogisticsSettingForIntermediary extends BaseEntity {
   @JoinColumn({ name: 'intermediary_id', referencedColumnName: 'id' })
   intermediary: Account;
 }
+
+export type TLogisticsSettingForIntermediary = Pick<LogisticsSettingForIntermediary, 'intermediaryId' | 'stop'> & {
+  id: string;
+  intermediary: Account;
+};

--- a/server/app/src/logistics/setting/logistics/entities/setting.entity.ts
+++ b/server/app/src/logistics/setting/logistics/entities/setting.entity.ts
@@ -29,3 +29,9 @@ export class LogisticsSettingForLogistics extends BaseEntity {
   @OneToMany(() => Route, (route) => route.setting)
   routes: Route[];
 }
+
+export type TLogisticsSettingForLogistics = Pick<LogisticsSettingForLogistics, 'logisticsId' | 'deliveryType'> & {
+  id: string;
+  logistics: Account;
+  routes: Route[];
+};

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -57,6 +57,7 @@
     "@felte/validator-zod": "^0.3.3",
     "dayjs": "^1.11.7",
     "felte": "^1.2.6",
+    "svelte-steps": "^2.4.1",
     "zod": "^3.9.8"
   }
 }

--- a/web/app/src/models/Logistics.ts
+++ b/web/app/src/models/Logistics.ts
@@ -1,0 +1,35 @@
+import { baseAPI } from '../api/base';
+import type { CreateLogisticsSettingForIntermediaryDto } from './../../../../server/app/src/logistics/setting/intermediary/dto/create-setting.dto';
+import type { TLogisticsSettingForIntermediary } from './../../../../server/app/src/logistics/setting/intermediary/entities/setting.entity';
+import type { TLogisticsSettingForLogistics } from './../../../../server/app/src/logistics/setting/logistics/entities/setting.entity';
+import type { Jsonify } from 'type-fest';
+
+export type TLogisticsSetting = Jsonify<TLogisticsSettingForLogistics>;
+export type TIntermediarySetting = Jsonify<TLogisticsSettingForIntermediary>;
+export type TIntermediarySettingForm = Jsonify<CreateLogisticsSettingForIntermediaryDto>;
+
+export class LogisticsRepository {
+  get baseEndpoint(): string {
+    return 'logistics';
+  }
+
+  async getLogisticsSetting(id: string): Promise<TLogisticsSetting> {
+    return await baseAPI<TLogisticsSetting>({
+      endpoint: `${this.baseEndpoint}/setting/logistics/${id}`,
+    });
+  }
+
+  async getIntermediarySetting(id: string): Promise<TIntermediarySetting> {
+    return await baseAPI<TIntermediarySetting>({
+      endpoint: `${this.baseEndpoint}/setting/intermediary/${id}`,
+    });
+  }
+
+  async updateIntermediarySetting(id: string, body: TIntermediarySettingForm): Promise<TIntermediarySetting> {
+    return await baseAPI<TIntermediarySetting>({
+      endpoint: `${this.baseEndpoint}/setting/intermediary/${id}`,
+      method: 'PUT',
+      body,
+    });
+  }
+}

--- a/web/app/src/pages/logistics/setting/_components/StopSelectWizardDialog.svelte
+++ b/web/app/src/pages/logistics/setting/_components/StopSelectWizardDialog.svelte
@@ -1,0 +1,252 @@
+<script lang="ts">
+  import { goto } from '@roxi/routify';
+  import Button from '@smui/button';
+  import CircularProgress from '@smui/circular-progress';
+  import Dialog, { Title, Content, Actions } from '@smui/dialog';
+  import List, { Item, Graphic, Text } from '@smui/list';
+  import Radio from '@smui/radio';
+  import { Steps } from 'svelte-steps';
+  import { USER_ATTRIBUTE } from '../../../../constants/account';
+  import { LogisticsRepository } from '../../../../models/Logistics';
+  import { AccountService } from '../../../../services/AccountService';
+  import { profile } from '../../../../stores/Account';
+  import { markAsLogoutState } from '../../../../stores/Login';
+  import { addToast } from '../../../../stores/Toast';
+
+  $: logisticsRepository = new LogisticsRepository();
+
+  export let open = false;
+  export let selectedAction = (stop: string) => {
+    stop;
+  };
+
+  const SELECT_STOP_STEPS = {
+    select_shipper: {
+      text: '配送者選択',
+      index: 0,
+    },
+    select_route: {
+      text: '路線選択',
+      index: 1,
+    },
+    select_stop: {
+      text: 'バス停選択',
+      index: 2,
+    },
+  };
+
+  let currentStep = SELECT_STOP_STEPS.select_shipper.index;
+
+  let steps = [
+    { text: SELECT_STOP_STEPS.select_shipper.text },
+    { text: SELECT_STOP_STEPS.select_route.text },
+    { text: SELECT_STOP_STEPS.select_stop.text },
+  ];
+
+  function handleError(err, operation) {
+    switch (err.error || err.message) {
+      case 'Bad Request':
+        addToast({
+          message: `${operation}に失敗しました。開発者へお問い合わせください。`,
+          type: 'error',
+        });
+        break;
+      case 'Unauthorized':
+        markAsLogoutState();
+        addToast({
+          message: '認証が切れました。再度ログインしてください。',
+          type: 'error',
+        });
+        $goto('/login');
+        break;
+      default:
+        addToast({
+          message: `${operation}に失敗しました。もう一度時間をおいて再読み込みしてください。`,
+          type: 'error',
+        });
+        break;
+    }
+  }
+
+  async function fetchLogistics() {
+    try {
+      const logistics = await new AccountService().getLogistics();
+      if ($profile.attribute === USER_ATTRIBUTE.producer) {
+        logistics.push($profile);
+      }
+      return Object.fromEntries(logistics.map(({ id, name }) => [id, name]));
+    } catch (err) {
+      handleError(err, '物流業者の取得');
+      return [];
+    }
+  }
+
+  async function fetchLogisticsSettingRoutes() {
+    try {
+      const setting = await logisticsRepository.getLogisticsSetting(selectedShipperId);
+      return Object.fromEntries(setting.routes.map(({ id, name }) => [id, name]));
+    } catch (err) {
+      handleError(err, '物流設定の取得');
+      return [];
+    }
+  }
+
+  async function fetchLogisticsSettingStops() {
+    try {
+      const setting = await logisticsRepository.getLogisticsSetting(selectedShipperId);
+      return setting.routes
+        .find((route) => route.id === selectedRouteId)
+        .trips[0]?.timetables.map((timetable) => timetable.stop);
+    } catch (err) {
+      handleError(err, '物流業者設定の取得');
+      return [];
+    }
+  }
+
+  let selectedShipperId = '';
+  let selectedRouteId = '';
+  let selectedStop = '';
+
+  async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
+    switch (e.detail.action) {
+      case 'selected':
+        await selected();
+        break;
+      default:
+        // NOP
+        break;
+    }
+  }
+
+  async function selected() {
+    selectedAction(selectedStop);
+    currentStep = SELECT_STOP_STEPS.select_shipper.index;
+    selectedShipperId = '';
+    selectedRouteId = '';
+    selectedStop = '';
+  }
+</script>
+
+<Dialog bind:open bind:selectedAction on:SMUIDialog:closed={onDialogClosedHandle}>
+  <Title>
+    <div class="text-xs">
+      <Steps {steps} current={currentStep} size="2rem" clickable={false} />
+    </div>
+    <div class="mt-5 text-sm">
+      {#if SELECT_STOP_STEPS.select_shipper.index === currentStep}
+        <p>バス停を絞り込むため物流業者を選択してください。</p>
+      {:else if SELECT_STOP_STEPS.select_route.index === currentStep}
+        <p>バス停を絞り込むため路線を選択してください。</p>
+      {:else if SELECT_STOP_STEPS.select_stop.index === currentStep}
+        <p>バス停を選択してください。</p>
+      {/if}
+    </div>
+  </Title>
+  <Content>
+    <div class="max-h-[300px]">
+      {#if open}
+        {#if SELECT_STOP_STEPS.select_shipper.index === currentStep}
+          {#await fetchLogistics()}
+            <div style="display: flex; justify-content: center">
+              <CircularProgress style=" width: 32px;height: 160px;" indeterminate />
+            </div>
+          {:then logistics}
+            <List radioList>
+              {#each Object.keys(logistics) as shipper}
+                <Item>
+                  <Graphic>
+                    <Radio bind:group={selectedShipperId} value={shipper} />
+                  </Graphic>
+                  <Text>{logistics[shipper]}</Text>
+                </Item>
+              {/each}
+            </List>
+          {/await}
+        {:else if SELECT_STOP_STEPS.select_route.index === currentStep}
+          {#await fetchLogisticsSettingRoutes()}
+            <div style="display: flex; justify-content: center">
+              <CircularProgress style=" width: 32px;height: 160px;" indeterminate />
+            </div>
+          {:then routes}
+            <List radioList>
+              {#each Object.keys(routes) as route}
+                <Item>
+                  <Graphic>
+                    <Radio bind:group={selectedRouteId} value={route} />
+                  </Graphic>
+                  <Text>{routes[route]}</Text>
+                </Item>
+              {/each}
+            </List>
+          {/await}
+        {:else if SELECT_STOP_STEPS.select_stop.index === currentStep}
+          {#await fetchLogisticsSettingStops()}
+            <div style="display: flex; justify-content: center">
+              <CircularProgress style=" width: 32px;height: 160px;" indeterminate />
+            </div>
+          {:then stops}
+            <List radioList>
+              {#each stops as stop}
+                <Item>
+                  <Graphic>
+                    <Radio bind:group={selectedStop} value={stop} />
+                  </Graphic>
+                  <Text>{stop}</Text>
+                </Item>
+              {/each}
+            </List>
+          {/await}
+        {/if}
+      {/if}
+    </div>
+  </Content>
+  <Actions>
+    {#if SELECT_STOP_STEPS.select_shipper.index === currentStep}
+      <Button
+        disabled={!selectedShipperId}
+        class="w-[100px]  rounded-full px-4 py-2"
+        color="secondary"
+        variant="raised"
+        on:click={() => (currentStep = SELECT_STOP_STEPS.select_route.index)}
+      >
+        <p class="text-lg font-bold">次へ</p>
+      </Button>
+    {:else if SELECT_STOP_STEPS.select_route.index === currentStep}
+      <Button
+        class="w-[100px]  rounded-full px-4 py-2"
+        color="secondary"
+        variant="outlined"
+        on:click={() => (currentStep = SELECT_STOP_STEPS.select_shipper.index)}
+      >
+        <p class="text-lg font-bold">前へ</p>
+      </Button>
+      <Button
+        disabled={!selectedRouteId}
+        class="w-[100px]  rounded-full px-4 py-2"
+        color="secondary"
+        variant="raised"
+        on:click={() => (currentStep = SELECT_STOP_STEPS.select_stop.index)}
+      >
+        <p class="text-lg font-bold">次へ</p>
+      </Button>
+    {:else if SELECT_STOP_STEPS.select_stop.index === currentStep}
+      <Button
+        class="w-[100px]  rounded-full px-4 py-2"
+        color="secondary"
+        variant="outlined"
+        on:click={() => (currentStep = SELECT_STOP_STEPS.select_route.index)}
+      >
+        <p class="text-lg font-bold">前へ</p>
+      </Button>
+      <Button
+        disabled={!selectedStop}
+        class="w-[100px]  rounded-full px-4 py-2"
+        color="secondary"
+        variant="raised"
+        action="selected"
+      >
+        <p class="text-lg font-bold">選択</p>
+      </Button>
+    {/if}
+  </Actions>
+</Dialog>

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -4719,6 +4719,11 @@ svelte-preprocess@^5.0.4:
     sorcery "^0.11.0"
     strip-indent "^3.0.0"
 
+svelte-steps@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/svelte-steps/-/svelte-steps-2.4.1.tgz#64e055735818e81454e1ca5be8b7b9fe23a8b239"
+  integrity sha512-2Xq2lLcGJf3PaEY46f1w5s+/O+tLl4U2V+Z+sCeoUm/kEPFXeZP/aFr2JVKwdzSlXCT+raz75xqXtnZrPWJ0zA==
+
 svelte2tsx@^0.5.12:
   version "0.5.22"
   resolved "https://registry.yarnpkg.com/svelte2tsx/-/svelte2tsx-0.5.22.tgz#3d3610691b062cd4679ce60ebaef53b896aa51ba"


### PR DESCRIPTION
# 概要

引渡し業者向け物流設定の表示と設定ができるように対応した

# 注意点

* モジュールの追加があるため、モジュールを取り込んでください

```
cd (poject_root)/web/app
yarn install --frozen-lockfile
```

* 動作確認するためにはあらかじめ物中業者向け物流設定にデータを登録しておいてください

  * 物流業者をサインアップする
  * DBのlogisitics_setting_for_logisticsテーブルで登録されているデータのdelevery_typeをrouteにする
  * DBのrouteテーブルにデータを1つ以上登録する（logisitics_setting_idでlogisitics_setting_for_logisticsのidと紐付けること）
  * DBのtripテーブルにデータを1つ以上登録する（route_idでrouteテーブルのidと紐付けること）
  * DBのtimetableテーブルにデータを1つ以上登録する（trip_idでtripテーブルのidと紐付けること）

# 変更点
  
* (web)

  * ウィザードの進捗表示のためsvelte-stepsモジュールを導入
  * 引渡し業者向け物流設定画面の表示と設定に対応
  * 引渡し業者向け物流設定画面で最寄りのバス停選択をウィザード形式で行えるように対応

* (back)

  * 物流業者向け物流設定を取得するAPIを提供
  * 引渡し業者向け物流設定を取得するAPIを提供
  * 引渡し業者向け物流設定を更新するAPIを提供

# 動作確認内容

  1. 引渡し業者でログイン
  2. サイドメニューから物流設定画面を開き、引渡し業者向け物流設定が表示されることを確認（初期状態では未選択となっていること）
  3. 最寄りのバス停の「変更」ボタンを押下し、バス停選択ウィザードダイアログが開くことを確認
  4. 物流業者選択ステップでシステムに登録されている物流業者の一覧が選択肢にあることを確認
  5. 物流業者選択ステップで任意の物流業者を選択し、「次へ」ボタンを押下して、路線選択ステップに進むことを確認
  6. 路線選択ステップで物流業者選択ステップで選択した物流業者の物流設定されている路線の一覧が選択肢にあることを確認
  7. 路線選択ステップで任意の路線を選択し、「次へ」ボタンを押下して、バス停選択ステップに進むことを確認（「前へ」ボタンで戻れることも確認）
  8. バス停選択ステップで路線選択ステップで選択した路線の便一覧が選択肢にあることを確認
  9. バス停選択ステップで任意のバス停を選択し、「選択」ボタンを押下して、バス停選択ウィザードダイアログが閉じることを確認（「前へ」ボタンで戻れることも確認）
  10. バス停選択ステップで「選択」ボタンを押下したときに、引渡し業者向け物流設定に選択したバス停が反映され、引渡し業者向け物流設定画面においても選択したバス停が表示されていることを確認

   