### PR TITLE
生産者向け物流設定の表示と設定ができる

### DIFF
--- a/server/app/src/account/account.controller.ts
+++ b/server/app/src/account/account.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Request, Body, HttpCode, HttpStatus, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Request, Body, HttpCode, HttpStatus, UseGuards, Query } from '@nestjs/common';
 import { AccountService } from './account.service';
 import { AuthService, PasswordOmitAccount } from './auth.service';
 import { CreateAccountDto } from './dto/create-account.dto';
@@ -35,7 +35,7 @@ export class AccountController {
 
   @UseGuards(JwtAuthGuard)
   @Get('/logistics')
-  async getLogistics() {
-    return await this.accountService.getLogistics();
+  async getLogistics(@Query('delivery-type') deliveryType: string) {
+    return await this.accountService.getLogistics(deliveryType);
   }
 }

--- a/server/app/src/account/account.service.ts
+++ b/server/app/src/account/account.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, ConflictException, InternalServerErrorException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as bcrypt from 'bcrypt';
-import { Repository, IsNull } from 'typeorm';
+import { Repository, IsNull, FindOptionsWhere } from 'typeorm';
 import {
   LogisticsSettingForIntermediary,
   INTERMEDIARY_DEFAULT_STOP,
@@ -80,9 +80,19 @@ export class AccountService {
     });
   }
 
-  async getLogistics(): Promise<Account[] | undefined> {
+  async getLogistics(deliveryType: string): Promise<Account[] | undefined> {
+    let where: FindOptionsWhere<Account> = { attribute: USER_ATTRIBUTE.logistics, deletedAt: IsNull() };
+    if (deliveryType && DELIVERY_TYPE[deliveryType]) {
+      where = {
+        ...where,
+        logisticsSettingForLogistics: {
+          deliveryType: DELIVERY_TYPE[deliveryType],
+        },
+      };
+    }
     return await this.accountRepository.find({
-      where: { attribute: USER_ATTRIBUTE.logistics, deletedAt: IsNull() },
+      where,
+      relations: { logisticsSettingForLogistics: true },
     });
   }
 }

--- a/server/app/src/logistics/logistics.controller.ts
+++ b/server/app/src/logistics/logistics.controller.ts
@@ -3,12 +3,18 @@ import { Account } from 'src/account/entities/account.entity';
 import { GetAccount } from 'src/account/get-account.decorator';
 import { JwtAuthGuard } from 'src/account/jwt-auth.guard';
 import { CreateLogisticsSettingForIntermediaryDto } from 'src/logistics/setting/intermediary/dto/create-setting.dto';
+import { CreateLogisticsSettingForProducerDto } from 'src/logistics/setting/producer/dto/create-setting.dto';
 import { LogisticsService } from './logistics.service';
 
 @Controller('logistics')
 @UseGuards(JwtAuthGuard)
 export class LogisticsController {
   constructor(private readonly logisticService: LogisticsService) {}
+
+  @Get('/setting/producer/:producerId')
+  async getProducerSetting(@Param('producerId') producerId: string) {
+    return this.logisticService.getProducerSetting(producerId);
+  }
 
   @Get('/setting/logistics/:logisticsId')
   async getLogisticsSetting(@Param('logisticsId') logisticsId: string) {
@@ -18,6 +24,15 @@ export class LogisticsController {
   @Get('/setting/intermediary/:intermediaryId')
   async getIntermediarySetting(@Param('intermediaryId') intermediaryId: string) {
     return this.logisticService.getIntermediarySetting(intermediaryId);
+  }
+
+  @Put('/setting/producer/:producerId')
+  async updateProducerSetting(
+    @Param('producerId') producerId: string,
+    @Body() dto: CreateLogisticsSettingForProducerDto,
+    @GetAccount() account: Account,
+  ) {
+    return this.logisticService.updateProducerSetting(account, producerId, dto);
   }
 
   @Put('/setting/intermediary/:intermediaryId')

--- a/server/app/src/logistics/logistics.module.ts
+++ b/server/app/src/logistics/logistics.module.ts
@@ -5,9 +5,17 @@ import { LogisticsController } from './logistics.controller';
 import { LogisticsService } from './logistics.service';
 import { LogisticsSettingForIntermediary } from './setting/intermediary/entities/setting.entity';
 import { LogisticsSettingForLogistics } from './setting/logistics/entities/setting.entity';
+import { LogisticsSettingForProducer } from './setting/producer/entities/setting.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([LogisticsSettingForLogistics, LogisticsSettingForIntermediary, Account])],
+  imports: [
+    TypeOrmModule.forFeature([
+      LogisticsSettingForProducer,
+      LogisticsSettingForLogistics,
+      LogisticsSettingForIntermediary,
+      Account,
+    ]),
+  ],
   controllers: [LogisticsController],
   providers: [LogisticsService],
   exports: [LogisticsService],

--- a/server/app/src/logistics/logistics.service.ts
+++ b/server/app/src/logistics/logistics.service.ts
@@ -4,11 +4,15 @@ import { Account } from 'src/account/entities/account.entity';
 import { CreateLogisticsSettingForIntermediaryDto } from 'src/logistics/setting/intermediary/dto/create-setting.dto';
 import { LogisticsSettingForIntermediary } from 'src/logistics/setting/intermediary/entities/setting.entity';
 import { LogisticsSettingForLogistics } from 'src/logistics/setting/logistics/entities/setting.entity';
+import { CreateLogisticsSettingForProducerDto } from 'src/logistics/setting/producer/dto/create-setting.dto';
+import { LogisticsSettingForProducer } from 'src/logistics/setting/producer/entities/setting.entity';
 import { Repository } from 'typeorm';
 
 @Injectable()
 export class LogisticsService {
   constructor(
+    @InjectRepository(LogisticsSettingForProducer)
+    private producerSettingRepository: Repository<LogisticsSettingForProducer>,
     @InjectRepository(LogisticsSettingForLogistics)
     private logisticsSettingRepository: Repository<LogisticsSettingForLogistics>,
     @InjectRepository(LogisticsSettingForIntermediary)
@@ -21,8 +25,35 @@ export class LogisticsService {
       .then((setting) => setting);
   }
 
+  async getProducerSetting(producerId: string): Promise<LogisticsSettingForProducer> {
+    return await this.producerSettingRepository.findOne({ where: { producerId } }).then((setting) => setting);
+  }
+
   async getIntermediarySetting(intermediaryId: string): Promise<LogisticsSettingForIntermediary> {
     return await this.intermediarySettingRepository.findOne({ where: { intermediaryId } }).then((setting) => setting);
+  }
+
+  async updateProducerSetting(
+    account: Account,
+    producerId: string,
+    dto: CreateLogisticsSettingForProducerDto,
+  ): Promise<LogisticsSettingForProducer> {
+    const setting = await this.producerSettingRepository
+      .findOne({
+        where: { producerId },
+      })
+      .then((setting) => setting);
+
+    if (!setting) {
+      throw new BadRequestException();
+    }
+    if (setting.producerId !== account.id) {
+      throw new BadRequestException();
+    }
+
+    setting.stop = dto.stop;
+    this.producerSettingRepository.save(setting);
+    return setting;
   }
 
   async updateIntermediarySetting(

--- a/server/app/src/logistics/setting/producer/dto/create-setting.dto.ts
+++ b/server/app/src/logistics/setting/producer/dto/create-setting.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class CreateLogisticsSettingForProducerDto {
+  @IsNotEmpty()
+  @IsString()
+  stop: string;
+}

--- a/server/app/src/logistics/setting/producer/entities/setting.entity.ts
+++ b/server/app/src/logistics/setting/producer/entities/setting.entity.ts
@@ -26,3 +26,12 @@ export class LogisticsSettingForProducer extends BaseEntity {
   @OneToMany(() => UserConsolidationDefine, (consolidation) => consolidation.setting)
   consolidations: UserConsolidationDefine[];
 }
+
+export type TLogisticsSettingForProducer = Pick<
+  LogisticsSettingForProducer,
+  'producerId' | 'stop' | 'consolidations'
+> & {
+  id: string;
+  intermediary: Account;
+  consolidations: UserConsolidationDefine[];
+};

--- a/server/app/src/logistics/setting/producer/entities/setting.entity.ts
+++ b/server/app/src/logistics/setting/producer/entities/setting.entity.ts
@@ -27,11 +27,7 @@ export class LogisticsSettingForProducer extends BaseEntity {
   consolidations: UserConsolidationDefine[];
 }
 
-export type TLogisticsSettingForProducer = Pick<
-  LogisticsSettingForProducer,
-  'producerId' | 'stop' | 'consolidations'
-> & {
+export type TLogisticsSettingForProducer = Pick<LogisticsSettingForProducer, 'producerId' | 'stop'> & {
   id: string;
-  intermediary: Account;
-  consolidations: UserConsolidationDefine[];
+  producer: Account;
 };

--- a/web/app/src/constants/account.ts
+++ b/web/app/src/constants/account.ts
@@ -21,3 +21,8 @@ export const USER_ATTRIBUTE_LABEL = {
   logistics: '物流業者',
   intermediary: '引渡し業者',
 };
+
+export const DELIVERY_TYPE = {
+  route: 'route',
+  direct: 'direct',
+};

--- a/web/app/src/constants/account.ts
+++ b/web/app/src/constants/account.ts
@@ -21,8 +21,3 @@ export const USER_ATTRIBUTE_LABEL = {
   logistics: '物流業者',
   intermediary: '引渡し業者',
 };
-
-export const DELIVERY_TYPE = {
-  route: 'route',
-  direct: 'direct',
-};

--- a/web/app/src/constants/logistics.ts
+++ b/web/app/src/constants/logistics.ts
@@ -1,0 +1,4 @@
+export const DELIVERY_TYPE = {
+  route: 'route',
+  direct: 'direct',
+};

--- a/web/app/src/models/Logistics.ts
+++ b/web/app/src/models/Logistics.ts
@@ -2,15 +2,25 @@ import { baseAPI } from '../api/base';
 import type { CreateLogisticsSettingForIntermediaryDto } from './../../../../server/app/src/logistics/setting/intermediary/dto/create-setting.dto';
 import type { TLogisticsSettingForIntermediary } from './../../../../server/app/src/logistics/setting/intermediary/entities/setting.entity';
 import type { TLogisticsSettingForLogistics } from './../../../../server/app/src/logistics/setting/logistics/entities/setting.entity';
+import type { CreateLogisticsSettingForProducerDto } from './../../../../server/app/src/logistics/setting/producer/dto/create-setting.dto';
+import type { TLogisticsSettingForProducer } from './../../../../server/app/src/logistics/setting/producer/entities/setting.entity';
 import type { Jsonify } from 'type-fest';
 
+export type TProducerSetting = Jsonify<TLogisticsSettingForProducer>;
 export type TLogisticsSetting = Jsonify<TLogisticsSettingForLogistics>;
 export type TIntermediarySetting = Jsonify<TLogisticsSettingForIntermediary>;
+export type TProducerSettingForm = Jsonify<CreateLogisticsSettingForProducerDto>;
 export type TIntermediarySettingForm = Jsonify<CreateLogisticsSettingForIntermediaryDto>;
 
 export class LogisticsRepository {
   get baseEndpoint(): string {
     return 'logistics';
+  }
+
+  async getProducerSetting(id: string): Promise<TProducerSetting> {
+    return await baseAPI<TProducerSetting>({
+      endpoint: `${this.baseEndpoint}/setting/producer/${id}`,
+    });
   }
 
   async getLogisticsSetting(id: string): Promise<TLogisticsSetting> {
@@ -22,6 +32,14 @@ export class LogisticsRepository {
   async getIntermediarySetting(id: string): Promise<TIntermediarySetting> {
     return await baseAPI<TIntermediarySetting>({
       endpoint: `${this.baseEndpoint}/setting/intermediary/${id}`,
+    });
+  }
+
+  async updateProducerSetting(id: string, body: TProducerSettingForm): Promise<TProducerSetting> {
+    return await baseAPI<TProducerSetting>({
+      endpoint: `${this.baseEndpoint}/setting/producer/${id}`,
+      method: 'PUT',
+      body,
     });
   }
 

--- a/web/app/src/pages/logistics/setting/_components/IntermediarySettingForm.svelte
+++ b/web/app/src/pages/logistics/setting/_components/IntermediarySettingForm.svelte
@@ -13,12 +13,16 @@
 
   let isOpen = false;
   let selectedStop = 'Unselected';
-  let selectedAction = (stop: string) => {
+  let selectedAction = async (stop: string) => {
+    const operation = '物流設定の更新';
     try {
       selectedStop = stop;
-      logisticsRepository.updateIntermediarySetting($profile.id, { stop });
+      await logisticsRepository.updateIntermediarySetting($profile.id, { stop });
+      addToast({
+        message: `${operation}が完了しました。`,
+      });
     } catch (err) {
-      handleError(err, '物流設定の更新');
+      handleError(err, operation);
     }
   };
 

--- a/web/app/src/pages/logistics/setting/_components/ProducerSettingForm.svelte
+++ b/web/app/src/pages/logistics/setting/_components/ProducerSettingForm.svelte
@@ -13,12 +13,16 @@
 
   let isOpen = false;
   let selectedStop = 'Unselected';
-  let selectedAction = (stop: string) => {
+  let selectedAction = async (stop: string) => {
+    const operation = '物流設定の更新';
     try {
       selectedStop = stop;
-      logisticsRepository.updateProducerSetting($profile.id, { stop });
+      await logisticsRepository.updateProducerSetting($profile.id, { stop });
+      addToast({
+        message: `${operation}が完了しました。`,
+      });
     } catch (err) {
-      handleError(err, '物流設定の更新');
+      handleError(err, operation);
     }
   };
 

--- a/web/app/src/pages/logistics/setting/_components/ProducerSettingForm.svelte
+++ b/web/app/src/pages/logistics/setting/_components/ProducerSettingForm.svelte
@@ -1,6 +1,91 @@
 <script lang="ts">
+  import { goto } from '@roxi/routify';
+  import Button from '@smui/button';
+  import CircularProgress from '@smui/circular-progress';
+  import { onMount } from 'svelte';
+  import { LogisticsRepository } from '../../../../models/Logistics';
+  import { profile } from '../../../../stores/Account';
+  import { markAsLogoutState } from '../../../../stores/Login';
+  import { addToast } from '../../../../stores/Toast';
+  import StopSelectWizardDialog from './StopSelectWizardDialog.svelte';
+
+  $: logisticsRepository = new LogisticsRepository();
+
+  let isOpen = false;
+  let selectedStop = 'Unselected';
+  let selectedAction = (stop: string) => {
+    try {
+      selectedStop = stop;
+      logisticsRepository.updateProducerSetting($profile.id, { stop });
+    } catch (err) {
+      handleError(err, '物流設定の更新');
+    }
+  };
+
+  let isMounted = false;
+
+  onMount(async () => {
+    try {
+      const setting = await logisticsRepository.getProducerSetting($profile.id);
+      selectedStop = setting.stop;
+    } catch (err) {
+      handleError(err, '物流設定の取得');
+    } finally {
+      isMounted = true;
+    }
+  });
+
+  function handleError(err, operation) {
+    switch (err.error || err.message) {
+      case 'Bad Request':
+        addToast({
+          message: `${operation}に失敗しました。開発者へお問い合わせください。`,
+          type: 'error',
+        });
+        break;
+      case 'Unauthorized':
+        markAsLogoutState();
+        addToast({
+          message: '認証が切れました。再度ログインしてください。',
+          type: 'error',
+        });
+        $goto('/login');
+        break;
+      default:
+        addToast({
+          message: `${operation}に失敗しました。もう一度時間をおいて再読み込みしてください。`,
+          type: 'error',
+        });
+        break;
+    }
+  }
 </script>
 
-<div>
-  <p class="text-base">生産者向け物流設定</p>
-</div>
+{#if !isMounted}
+  <div style="display: flex; justify-content: center">
+    <CircularProgress style=" width: 32px;height: 160px;" indeterminate />
+  </div>
+{:else}
+  <div class="flex justify-center">
+    <div class="w-full lg:w-2/3 xl:w-1/2">
+      <h1 class="mt-3 border-l-8 border-solid border-l-primary bg-[#f4f4f4] px-3 py-2 text-lg text-[#494949]">
+        最寄りのバス停
+      </h1>
+      <div class="relative mx-5 my-3">
+        <p class="py-1 text-base">{selectedStop === 'Unselected' ? '未選択' : selectedStop}</p>
+        <div class="absolute inset-y-0 right-1 flex">
+          <Button
+            variant="raised"
+            class="w-[100px] rounded-full text-base "
+            color="secondary"
+            type="button"
+            on:click={() => (isOpen = true)}
+          >
+            <p>変更</p>
+          </Button>
+          <StopSelectWizardDialog bind:open={isOpen} bind:selectedAction />
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/web/app/src/pages/logistics/setting/_components/StopSelectWizardDialog.svelte
+++ b/web/app/src/pages/logistics/setting/_components/StopSelectWizardDialog.svelte
@@ -6,7 +6,7 @@
   import List, { Item, Graphic, Text } from '@smui/list';
   import Radio from '@smui/radio';
   import { Steps } from 'svelte-steps';
-  import { DELIVERY_TYPE } from '../../../../constants/account';
+  import { DELIVERY_TYPE } from '../../../../constants/logistics';
   import { LogisticsRepository } from '../../../../models/Logistics';
   import { AccountService } from '../../../../services/AccountService';
   import { markAsLogoutState } from '../../../../stores/Login';

--- a/web/app/src/pages/logistics/setting/_components/StopSelectWizardDialog.svelte
+++ b/web/app/src/pages/logistics/setting/_components/StopSelectWizardDialog.svelte
@@ -6,10 +6,9 @@
   import List, { Item, Graphic, Text } from '@smui/list';
   import Radio from '@smui/radio';
   import { Steps } from 'svelte-steps';
-  import { USER_ATTRIBUTE } from '../../../../constants/account';
+  import { DELIVERY_TYPE } from '../../../../constants/account';
   import { LogisticsRepository } from '../../../../models/Logistics';
   import { AccountService } from '../../../../services/AccountService';
-  import { profile } from '../../../../stores/Account';
   import { markAsLogoutState } from '../../../../stores/Login';
   import { addToast } from '../../../../stores/Toast';
 
@@ -70,10 +69,7 @@
 
   async function fetchLogistics() {
     try {
-      const logistics = await new AccountService().getLogistics();
-      if ($profile.attribute === USER_ATTRIBUTE.producer) {
-        logistics.push($profile);
-      }
+      const logistics = await new AccountService().getLogistics(DELIVERY_TYPE.route);
       return Object.fromEntries(logistics.map(({ id, name }) => [id, name]));
     } catch (err) {
       handleError(err, '物流業者の取得');

--- a/web/app/src/services/AccountService.ts
+++ b/web/app/src/services/AccountService.ts
@@ -73,10 +73,11 @@ export class AccountService {
     }
   }
 
-  async getLogistics(): Promise<Record<string, string>[]> {
+  async getLogistics(deliveryType?: string): Promise<Record<string, string>[]> {
     try {
+      const endpoint = 'account/logistics' + (deliveryType ? `?delivery-type=${deliveryType}` : '');
       return await baseAPI<Record<string, string>[]>({
-        endpoint: 'account/logistics',
+        endpoint: endpoint,
         method: 'GET',
       });
     } catch (err) {


### PR DESCRIPTION
# 概要

生産者向け物流設定の表示と設定ができるように対応しました。

# 変更点
  
* (web)

  * 生産者向け物流設定画面の表示と設定に対応
    * ただし混載定義の表示は未対応
  * 生産者向け物流設定画面で最寄りのバス停選択をウィザード形式で行えるように対応
    * 集荷・配送方法をdirectに設定している物流業者、および生産者をバス停選択の対象に含めないよう修正

* (back)

  * 生産者向け物流設定を取得するAPIを提供
  * 生産者向け物流設定を更新するAPIを提供
  * 物流業者の一覧を取得するAPIに、物流設定の集荷・配送方法でフィルターするためのクエリを追加

# 動作確認内容
### 物流設定画面の確認
  1. 生産者でログイン
  2. サイドメニューから物流設定画面を開き、生産者向け物流設定が表示されることを確認（初期状態では未選択となっていること）
  3. 最寄りのバス停の「変更」ボタンを押下し、バス停選択ウィザードダイアログが開くことを確認
  4. 物流業者選択ステップでシステムに登録されている物流業者の一覧が選択肢にあることを確認
      → 選択肢が集荷・配送方法がrouteに設定されている物流業者のみになっていることを確認
  5. 物流業者選択ステップで任意の物流業者を選択し、「次へ」ボタンを押下して、路線選択ステップに進むことを確認
  6. 路線選択ステップで物流業者選択ステップで選択した物流業者の物流設定されている路線の一覧が選択肢にあることを確認
  7. 路線選択ステップで任意の路線を選択し、「次へ」ボタンを押下して、バス停選択ステップに進むことを確認（「前へ」ボタンで戻れることも確認）
  8. バス停選択ステップで路線選択ステップで選択した路線の便一覧が選択肢にあることを確認
  9. バス停選択ステップで任意のバス停を選択し、「選択」ボタンを押下して、バス停選択ウィザードダイアログが閉じることを確認（「前へ」ボタンで戻れることも確認）
  10. バス停選択ステップで「選択」ボタンを押下したときに、引渡し業者向け物流設定に選択したバス停が反映され、引渡し業者向け物流設定画面においても選択したバス停が表示されていることを確認

### 物流業者の一覧取得APIの確認
#### バックエンド
以下はRESTクライアントツールでAPIを直接呼び出して動作確認した
  * クエリを指定せずに実行し、フィルターなしの結果を取得できることを確認
  * クエリパラメータに異常値を指定して実行し、フィルターなしの結果を取得できることを確認
  * クエリの値に異常値を指定して実行し、フィルターなしの結果を取得できることを確認
  * クエリの値にrouteを指定して実行し、集荷・配送方法がrouteの物流業者のみの結果を取得できることを確認
  * クエリの値にdirectを指定して実行し、集荷・配送方法がdirectの物流業者のみの結果を取得できることを確認
   
#### フロントエンド
  * web/app/src/services/AccountService.getLogistics() を引数なしで呼び出し、フィルターなしの結果を取得できることを確認