### PR TITLE
予約数量の最大値の変更、予約ステータス表示名の変更

### DIFF
--- a/server/app/src/reservation/entities/reservation.entity.ts
+++ b/server/app/src/reservation/entities/reservation.entity.ts
@@ -17,7 +17,7 @@ import {
 export const RESERVATION_STATUS = {
   canceled: 'canceled', // キャンセル
   packking: 'packking', // 出荷準備中
-  shipping: 'shipping', // 配送中
+  shipping: 'shipping', // 集荷配送中
   keeping: 'keeping', // 店舗保管中
   completed: 'completed', // 受取完了
 } as const;

--- a/web/app/src/models/Reservation.ts
+++ b/web/app/src/models/Reservation.ts
@@ -11,7 +11,7 @@ export type TReservationPackedForm = Jsonify<UpdateReservationForPackedDto>;
 export const statusToText: Record<TReservation['status'], string> = {
   canceled: '予約取り消し',
   packking: '出荷準備中',
-  shipping: '配送中',
+  shipping: '集荷配送中',
   keeping: '店舗保管中',
   completed: '受取完了',
 };
@@ -19,7 +19,7 @@ export const statusToText: Record<TReservation['status'], string> = {
 export const RESERVATION_STATUS = {
   canceled: 'canceled', // キャンセル
   packking: 'packking', // 出荷準備中
-  shipping: 'shipping', // 配送中
+  shipping: 'shipping', // 集荷配送中
   keeping: 'keeping', // 店舗保管中
   completed: 'completed', // 受取完了
 } as const;

--- a/web/app/src/pages/reservation/_components/ReservationForm.svelte
+++ b/web/app/src/pages/reservation/_components/ReservationForm.svelte
@@ -20,7 +20,9 @@
   let shopIds: Record<string, string> | undefined = undefined;
   let selectedProduct: TProduct;
   let totalPrice = 0;
-  let reservationMax: number;
+  let reservationRangeMax: number;
+  const RESERVATION_MAX = 100;
+  const RESERVATION_MIN = 1;
 
   onMount(async () => {
     try {
@@ -29,7 +31,7 @@
         new AccountService().getShops(),
       ]);
       shopIds = Object.fromEntries(shops.map(({ id, name }) => [id, name]));
-      reservationMax = selectedProduct.remaining > 100 ? 100 : selectedProduct.remaining;
+      reservationRangeMax = selectedProduct.remaining > RESERVATION_MAX ? RESERVATION_MAX : selectedProduct.remaining;
       totalPrice = selectedProduct.unitPrice;
     } catch (err) {
       switch (err.error || err.message) {
@@ -143,8 +145,8 @@
           required
           type={'number'}
           suffix="点"
-          input$min={1}
-          input$max={reservationMax}
+          input$min={RESERVATION_MIN}
+          input$max={reservationRangeMax}
           on:change={calcTotalPrice}
         />
       </div>

--- a/web/app/src/pages/reservation/_components/ReservationForm.svelte
+++ b/web/app/src/pages/reservation/_components/ReservationForm.svelte
@@ -20,6 +20,7 @@
   let shopIds: Record<string, string> | undefined = undefined;
   let selectedProduct: TProduct;
   let totalPrice = 0;
+  let reservationMax: number;
 
   onMount(async () => {
     try {
@@ -28,7 +29,7 @@
         new AccountService().getShops(),
       ]);
       shopIds = Object.fromEntries(shops.map(({ id, name }) => [id, name]));
-
+      reservationMax = selectedProduct.remaining > 100 ? 100 : selectedProduct.remaining;
       totalPrice = selectedProduct.unitPrice;
     } catch (err) {
       switch (err.error || err.message) {
@@ -143,7 +144,7 @@
           type={'number'}
           suffix="点"
           input$min={1}
-          input$max={selectedProduct.remaining}
+          input$max={reservationMax}
           on:change={calcTotalPrice}
         />
       </div>


### PR DESCRIPTION
# 概要
予約数量の最大値の変更、予約ステータス表示名の変更

# 変更点
- (web)
・予約ステータスの”配送中”を”集荷配送中に変更”
・予約数量の最大値を残り数量または100のいずれか小さい方にする

# 動作確認内容
- 予約一覧のステータスが集荷配送中になっていることを確認
- 予約時に残り数量が100より多い場合予約数量の最大値が100になっていること
- 予約時に残り数量が100より少ない場合予約数量の最大値が残り数量になっていること
- 残り数量が100より多い場合、少ない場合の境界値テスト