### PR TITLE
出品画面の衝撃選択欄の表示

### DIFF
--- a/web/app/src/constants/product.ts
+++ b/web/app/src/constants/product.ts
@@ -46,3 +46,10 @@ export const SHOCK_LEVEL = {
   weak: 45,
   very_weak: 30,
 };
+
+export const SHOCK_LEVEL_LABEL = {
+  very_strong: 'とても強い',
+  strong: '強い',
+  weak: '弱い',
+  very_weak: 'とても弱い',
+};

--- a/web/app/src/pages/product/_components/ProductForm.svelte
+++ b/web/app/src/pages/product/_components/ProductForm.svelte
@@ -284,22 +284,22 @@
           {/each}
         </Select>
       </div>
+    </div>
 
-      <div class="flex justify-center">
-        <Button
-          color="secondary"
-          variant="raised"
-          class="mr-4  mt-10 w-[150px] rounded-full px-4 py-2"
-          on:click={() => $goto('./')}
-          type="button"
-        >
-          <p class="black">キャンセル</p>
-        </Button>
+    <div class="flex justify-center">
+      <Button
+        color="secondary"
+        variant="raised"
+        class="mr-4  mt-10 w-[150px] rounded-full px-4 py-2"
+        on:click={() => $goto('./')}
+        type="button"
+      >
+        <p class="black">キャンセル</p>
+      </Button>
 
-        <Button variant="raised" class="mt-10 w-[150px] rounded-full px-4 py-2" color="secondary" type="submit">
-          <p class="black">出品</p>
-        </Button>
-      </div>
+      <Button variant="raised" class="mt-10 w-[150px] rounded-full px-4 py-2" color="secondary" type="submit">
+        <p class="black">出品</p>
+      </Button>
     </div>
   </form>
 </div>

--- a/web/app/src/pages/product/_components/ProductForm.svelte
+++ b/web/app/src/pages/product/_components/ProductForm.svelte
@@ -129,177 +129,177 @@
 
 <div>
   <form use:form class="grid justify-center">
-    <div class="w-full lg:w-2/3 xl:w-1/2">
+    <div class="w-full">
       <h1 class="mt-3 border-l-8 border-solid border-l-primary bg-[#f4f4f4] px-3 py-2 text-lg text-[#494949]">
         作物について
       </h1>
-    </div>
 
-    <div>
-      <Textfield
-        class="m-3 w-[300px]"
-        label="作物名"
-        bind:value={name}
-        required
-        type={'text'}
-        input$maxlength={30}
-        input$placeholder="例）とれたて苺"
-      />
-    </div>
+      <div>
+        <Textfield
+          class="m-3 w-[300px]"
+          label="作物名"
+          bind:value={name}
+          required
+          type={'text'}
+          input$maxlength={30}
+          input$placeholder="例）とれたて苺"
+        />
+      </div>
 
-    <div>
-      <Select class="m-3 w-[300px]" variant="standard" label="作物の種類" bind:value={kinds} required>
-        {#each Object.keys(CROP_KINDS) as kind}
-          <Option value={CROP_KINDS[kind]}>{CROP_KINDS_LABEL[kind]}</Option>
-        {/each}
-      </Select>
-    </div>
+      <div>
+        <Select class="m-3 w-[300px]" variant="standard" label="作物の種類" bind:value={kinds} required>
+          {#each Object.keys(CROP_KINDS) as kind}
+            <Option value={CROP_KINDS[kind]}>{CROP_KINDS_LABEL[kind]}</Option>
+          {/each}
+        </Select>
+      </div>
 
-    <div class="m-3">
-      <div class="label required input-title text-text-lightGray">説明</div>
-      <Textfield
-        class="w-[300px] sm:w-[300px] md:w-[600px]"
-        bind:value={description}
-        textarea
-        input$maxlength={500}
-        input$placeholder="例）甘くて美味しい、真っ赤な苺です。"
-      />
-    </div>
+      <div class="m-3">
+        <div class="label required input-title text-text-lightGray">説明</div>
+        <Textfield
+          class="w-[300px] sm:w-[300px] md:w-[600px]"
+          bind:value={description}
+          textarea
+          input$maxlength={500}
+          input$placeholder="例）甘くて美味しい、真っ赤な苺です。"
+        />
+      </div>
 
-    <div class="m-3">
-      <div class="label required input-title text-text-lightGray">予約期間</div>
-      <Textfield
-        class="m-3 w-[150px]"
-        variant="standard"
-        label="開始"
-        bind:value={startAt}
-        type="datetime-local"
-        required
-        input$min={START_AT_MIN_DATE_TIME.toISOString().slice(0, 16)}
-        input$max={START_AT_MAX_DATE_TIME.toISOString().slice(0, 16)}
-        on:click={showPicker}
-      />
-      <span class="label ml-3 mr-3 text-text-lightGray">～</span>
-      <Textfield
-        class="m-3 w-[150px]"
-        variant="standard"
-        label="終了"
-        bind:value={endAt}
-        type="datetime-local"
-        required
-        input$min={END_AT_MIN_DATE_TIME.toISOString().slice(0, 16)}
-        input$max={END_AT_MAX_DATE_TIME.toISOString().slice(0, 16)}
-        on:click={showPicker}
-      />
-    </div>
+      <div class="m-3">
+        <div class="label required input-title text-text-lightGray">予約期間</div>
+        <Textfield
+          class="m-3 w-[150px]"
+          variant="standard"
+          label="開始"
+          bind:value={startAt}
+          type="datetime-local"
+          required
+          input$min={START_AT_MIN_DATE_TIME.toISOString().slice(0, 16)}
+          input$max={START_AT_MAX_DATE_TIME.toISOString().slice(0, 16)}
+          on:click={showPicker}
+        />
+        <span class="label ml-3 mr-3 text-text-lightGray">～</span>
+        <Textfield
+          class="m-3 w-[150px]"
+          variant="standard"
+          label="終了"
+          bind:value={endAt}
+          type="datetime-local"
+          required
+          input$min={END_AT_MIN_DATE_TIME.toISOString().slice(0, 16)}
+          input$max={END_AT_MAX_DATE_TIME.toISOString().slice(0, 16)}
+          on:click={showPicker}
+        />
+      </div>
 
-    <div class="m-3">
-      <div class="label required input-title text-text-lightGray">単位</div>
-      <Textfield
-        class="m-3 w-[100px]"
-        label="単位数量"
-        bind:value={unitQuantity}
-        required
-        type={'number'}
-        input$min={0}
-        input$max={99999}
-      />
-      <Select class="m-3 w-[100px]" label="単位" variant="standard" bind:value={unit} required>
-        {#each Object.keys(CROP_UNITS) as kind}
-          <Option value={CROP_UNITS[kind]}>{CROP_UNITS_LABEL[kind]}</Option>
-        {/each}
-      </Select>
-    </div>
+      <div class="m-3">
+        <div class="label required input-title text-text-lightGray">単位</div>
+        <Textfield
+          class="m-3 w-[100px]"
+          label="単位数量"
+          bind:value={unitQuantity}
+          required
+          type={'number'}
+          input$min={0}
+          input$max={99999}
+        />
+        <Select class="m-3 w-[100px]" label="単位" variant="standard" bind:value={unit} required>
+          {#each Object.keys(CROP_UNITS) as kind}
+            <Option value={CROP_UNITS[kind]}>{CROP_UNITS_LABEL[kind]}</Option>
+          {/each}
+        </Select>
+      </div>
 
-    <div class="m-3">
-      <div class="label required input-title text-text-lightGray">単価</div>
-      <Textfield
-        class="m-3 w-[150px]"
-        label="金額"
-        bind:value={unitPrice}
-        required
-        type={'number'}
-        suffix="円"
-        input$min={0}
-        input$max={99999}
-      />
-    </div>
+      <div class="m-3">
+        <div class="label required input-title text-text-lightGray">単価</div>
+        <Textfield
+          class="m-3 w-[150px]"
+          label="金額"
+          bind:value={unitPrice}
+          required
+          type={'number'}
+          suffix="円"
+          input$min={0}
+          input$max={99999}
+        />
+      </div>
 
-    <div class="m-3">
-      <div class="label required input-title text-text-lightGray">出品数量</div>
-      <Textfield
-        class="ml-3 w-[150px]"
-        label="数量"
-        bind:value={quantity}
-        required
-        type={'number'}
-        suffix="点"
-        input$min={0}
-        input$max={999}
-      />
-    </div>
+      <div class="m-3">
+        <div class="label required input-title text-text-lightGray">出品数量</div>
+        <Textfield
+          class="ml-3 w-[150px]"
+          label="数量"
+          bind:value={quantity}
+          required
+          type={'number'}
+          suffix="点"
+          input$min={0}
+          input$max={999}
+        />
+      </div>
 
-    <div class="input-row m-3">
-      <div class="label required input-title text-text-lightGray">商品画像</div>
-      <div class="input-box">
-        <div
-          class="bg-white relative my-2 min-h-[200px] rounded-lg border-[1px] border-solid border-text-lightGray"
-          use:field
-        >
-          {#if !$data.image}
-            <div class="mt-16">
-              <!-- <img class="mx-auto" src="/images/icons/upload.svg" alt="" /> -->
-              <p class="mt-6 text-center text-sm font-bold text-text-lightGray">画像ファイルをアップロード</p>
-              <div class="mt-2 text-center">
-                <label class="upload-button mt-4 h-8 px-3 pt-2 text-text-lightGray">
-                  ファイルを選択
-                  <input type="file" accept="image/*" class="hidden" on:change={onImgSelect} />
-                </label>
+      <div class="input-row m-3">
+        <div class="label required input-title text-text-lightGray">商品画像</div>
+        <div class="input-box">
+          <div
+            class="bg-white relative my-2 min-h-[200px] rounded-lg border-[1px] border-solid border-text-lightGray"
+            use:field
+          >
+            {#if !$data.image}
+              <div class="mt-16">
+                <!-- <img class="mx-auto" src="/images/icons/upload.svg" alt="" /> -->
+                <p class="mt-6 text-center text-sm font-bold text-text-lightGray">画像ファイルをアップロード</p>
+                <div class="mt-2 text-center">
+                  <label class="upload-button mt-4 h-8 px-3 pt-2 text-text-lightGray">
+                    ファイルを選択
+                    <input type="file" accept="image/*" class="hidden" on:change={onImgSelect} />
+                  </label>
+                </div>
               </div>
-            </div>
-          {:else}
-            <div class="mb-9">
-              <IconButton on:click={onImgDelete}>
-                <CloseIcon />
-              </IconButton>
-              <div class="grid justify-center">
-                <img class="px-10" src={$data.image} alt="" width="360" height="360" />
+            {:else}
+              <div class="mb-9">
+                <IconButton on:click={onImgDelete}>
+                  <CloseIcon />
+                </IconButton>
+                <div class="grid justify-center">
+                  <img class="px-10" src={$data.image} alt="" width="360" height="360" />
+                </div>
               </div>
-            </div>
-          {/if}
+            {/if}
+          </div>
+          <div class="text-sm text-text-lightGray">最大アップロードサイズ:5MB</div>
         </div>
-        <div class="text-sm text-text-lightGray">最大アップロードサイズ:5MB</div>
       </div>
     </div>
 
-    <div class="w-full lg:w-2/3 xl:w-1/2">
+    <div class="w-full">
       <h1 class="mt-3 border-l-8 border-solid border-l-primary bg-[#f4f4f4] px-3 py-2 text-lg text-[#494949]">
         混載について
       </h1>
-    </div>
 
-    <div>
-      <Select class="m-3 w-[300px]" variant="standard" label="衝撃" bind:value={shockLevel} required>
-        {#each Object.keys(SHOCK_LEVEL) as shockLevel}
-          <Option value={SHOCK_LEVEL[shockLevel]}>{SHOCK_LEVEL_LABEL[shockLevel]}</Option>
-        {/each}
-      </Select>
-    </div>
+      <div>
+        <Select class="m-3 w-[300px]" variant="standard" label="衝撃" bind:value={shockLevel} required>
+          {#each Object.keys(SHOCK_LEVEL) as shockLevel}
+            <Option value={SHOCK_LEVEL[shockLevel]}>{SHOCK_LEVEL_LABEL[shockLevel]}</Option>
+          {/each}
+        </Select>
+      </div>
 
-    <div class="flex justify-center">
-      <Button
-        color="secondary"
-        variant="raised"
-        class="mr-4  mt-10 w-[150px] rounded-full px-4 py-2"
-        on:click={() => $goto('./')}
-        type="button"
-      >
-        <p class="black">キャンセル</p>
-      </Button>
+      <div class="flex justify-center">
+        <Button
+          color="secondary"
+          variant="raised"
+          class="mr-4  mt-10 w-[150px] rounded-full px-4 py-2"
+          on:click={() => $goto('./')}
+          type="button"
+        >
+          <p class="black">キャンセル</p>
+        </Button>
 
-      <Button variant="raised" class="mt-10 w-[150px] rounded-full px-4 py-2" color="secondary" type="submit">
-        <p class="black">出品</p>
-      </Button>
+        <Button variant="raised" class="mt-10 w-[150px] rounded-full px-4 py-2" color="secondary" type="submit">
+          <p class="black">出品</p>
+        </Button>
+      </div>
     </div>
   </form>
 </div>

--- a/web/app/src/pages/product/_components/ProductForm.svelte
+++ b/web/app/src/pages/product/_components/ProductForm.svelte
@@ -6,7 +6,14 @@
   import Textfield from '@smui/textfield';
   import { createField, createForm } from 'felte';
   import CloseIcon from '../../../components/icon/CloseIcon.svelte';
-  import { CROP_KINDS, CROP_KINDS_LABEL, CROP_UNITS, CROP_UNITS_LABEL, SHOCK_LEVEL } from '../../../constants/product';
+  import {
+    CROP_KINDS,
+    CROP_KINDS_LABEL,
+    CROP_UNITS,
+    CROP_UNITS_LABEL,
+    SHOCK_LEVEL,
+    SHOCK_LEVEL_LABEL,
+  } from '../../../constants/product';
   import { ShowableError } from '../../../models/Error';
   import { addToast } from '../../../stores/Toast';
   import { encodeFileToBase64 } from '../../../utils/file';
@@ -122,6 +129,12 @@
 
 <div>
   <form use:form class="grid justify-center">
+    <div class="w-full lg:w-2/3 xl:w-1/2">
+      <h1 class="mt-3 border-l-8 border-solid border-l-primary bg-[#f4f4f4] px-3 py-2 text-lg text-[#494949]">
+        作物について
+      </h1>
+    </div>
+
     <div>
       <Textfield
         class="m-3 w-[300px]"
@@ -257,6 +270,20 @@
         </div>
         <div class="text-sm text-text-lightGray">最大アップロードサイズ:5MB</div>
       </div>
+    </div>
+
+    <div class="w-full lg:w-2/3 xl:w-1/2">
+      <h1 class="mt-3 border-l-8 border-solid border-l-primary bg-[#f4f4f4] px-3 py-2 text-lg text-[#494949]">
+        混載について
+      </h1>
+    </div>
+
+    <div>
+      <Select class="m-3 w-[300px]" variant="standard" label="衝撃" bind:value={shockLevel} required>
+        {#each Object.keys(SHOCK_LEVEL) as shockLevel}
+          <Option value={SHOCK_LEVEL[shockLevel]}>{SHOCK_LEVEL_LABEL[shockLevel]}</Option>
+        {/each}
+      </Select>
     </div>
 
     <div class="flex justify-center">


### PR DESCRIPTION
# 概要
出品画面で混載条件を設定できるように対応しました。

# 変更点
- (web)
*  出品画面に作物入力見出しと混載入力見出しの表示を追加しました。
* 混載条件入力に対応しました。
　　ただし混載条件の選択は未対応（衝撃選択欄のみ対応）

# 動作確認内容
- 出品画面に見出しが表示されていること
- 出品画面から衝撃選択欄で"とても弱い"を選択し出品した際、そのpgadminのproductテーブルのレコードのshock_levelの値が 30 と登録されていること
- 出品画面から衝撃選択欄で"弱い"を選択し出品した際、そのpgadminのproductテーブルのレコードのshock_levelの値が 45 と登録されていること
- 出品画面から衝撃選択欄で"強い"を選択し出品した際、そのpgadminのproductテーブルのレコードのshock_levelの値が 60 と登録されていること
- 出品画面から衝撃選択欄で"とても強い"を選択し出品した際、そのpgadminのproductテーブルのレコードのshock_levelの値が 90 と登録されていること