### PR TITLE
ウィザード形式で出荷ができる

### DIFF
--- a/web/app/src/pages/login/index.svelte
+++ b/web/app/src/pages/login/index.svelte
@@ -8,6 +8,7 @@
   import { setAccountProfile } from '../../stores/Account';
   import { isLoggedIn, markAsLoginState } from '../../stores/Login';
   import { addToast } from '../../stores/Toast';
+  import { handleError } from '../../utils/error-handle-helper';
 
   let email = '';
   let password = '';
@@ -27,10 +28,7 @@
         });
       })
       .catch((err) => {
-        addToast({
-          message: err.message,
-          type: 'error',
-        });
+        handleError(err);
       });
   }
 

--- a/web/app/src/pages/logistics/setting/_components/IntermediarySettingForm.svelte
+++ b/web/app/src/pages/logistics/setting/_components/IntermediarySettingForm.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-  import { goto } from '@roxi/routify';
   import Button from '@smui/button';
   import CircularProgress from '@smui/circular-progress';
   import { onMount } from 'svelte';
   import { LogisticsRepository } from '../../../../models/Logistics';
   import { profile } from '../../../../stores/Account';
-  import { markAsLogoutState } from '../../../../stores/Login';
   import { addToast } from '../../../../stores/Toast';
+  import { handleError } from '../../../../utils/error-handle-helper';
   import StopSelectWizardDialog from './StopSelectWizardDialog.svelte';
 
   $: logisticsRepository = new LogisticsRepository();
@@ -38,31 +37,6 @@
       isMounted = true;
     }
   });
-
-  function handleError(err, operation) {
-    switch (err.error || err.message) {
-      case 'Bad Request':
-        addToast({
-          message: `${operation}に失敗しました。開発者へお問い合わせください。`,
-          type: 'error',
-        });
-        break;
-      case 'Unauthorized':
-        markAsLogoutState();
-        addToast({
-          message: '認証が切れました。再度ログインしてください。',
-          type: 'error',
-        });
-        $goto('/login');
-        break;
-      default:
-        addToast({
-          message: `${operation}に失敗しました。もう一度時間をおいて再読み込みしてください。`,
-          type: 'error',
-        });
-        break;
-    }
-  }
 </script>
 
 {#if !isMounted}

--- a/web/app/src/pages/logistics/setting/_components/ProducerSettingForm.svelte
+++ b/web/app/src/pages/logistics/setting/_components/ProducerSettingForm.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-  import { goto } from '@roxi/routify';
   import Button from '@smui/button';
   import CircularProgress from '@smui/circular-progress';
   import { onMount } from 'svelte';
   import { LogisticsRepository } from '../../../../models/Logistics';
   import { profile } from '../../../../stores/Account';
-  import { markAsLogoutState } from '../../../../stores/Login';
   import { addToast } from '../../../../stores/Toast';
+  import { handleError } from '../../../../utils/error-handle-helper';
   import StopSelectWizardDialog from './StopSelectWizardDialog.svelte';
 
   $: logisticsRepository = new LogisticsRepository();
@@ -38,31 +37,6 @@
       isMounted = true;
     }
   });
-
-  function handleError(err, operation) {
-    switch (err.error || err.message) {
-      case 'Bad Request':
-        addToast({
-          message: `${operation}に失敗しました。開発者へお問い合わせください。`,
-          type: 'error',
-        });
-        break;
-      case 'Unauthorized':
-        markAsLogoutState();
-        addToast({
-          message: '認証が切れました。再度ログインしてください。',
-          type: 'error',
-        });
-        $goto('/login');
-        break;
-      default:
-        addToast({
-          message: `${operation}に失敗しました。もう一度時間をおいて再読み込みしてください。`,
-          type: 'error',
-        });
-        break;
-    }
-  }
 </script>
 
 {#if !isMounted}

--- a/web/app/src/pages/logistics/setting/_components/StopSelectWizardDialog.svelte
+++ b/web/app/src/pages/logistics/setting/_components/StopSelectWizardDialog.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from '@roxi/routify';
   import Button from '@smui/button';
   import CircularProgress from '@smui/circular-progress';
   import Dialog, { Title, Content, Actions } from '@smui/dialog';
@@ -9,8 +8,7 @@
   import { DELIVERY_TYPE } from '../../../../constants/logistics';
   import { LogisticsRepository } from '../../../../models/Logistics';
   import { AccountService } from '../../../../services/AccountService';
-  import { markAsLogoutState } from '../../../../stores/Login';
-  import { addToast } from '../../../../stores/Toast';
+  import { handleError } from '../../../../utils/error-handle-helper';
 
   $: logisticsRepository = new LogisticsRepository();
 
@@ -41,31 +39,6 @@
     { text: SELECT_STOP_STEPS.select_route.text },
     { text: SELECT_STOP_STEPS.select_stop.text },
   ];
-
-  function handleError(err, operation) {
-    switch (err.error || err.message) {
-      case 'Bad Request':
-        addToast({
-          message: `${operation}に失敗しました。開発者へお問い合わせください。`,
-          type: 'error',
-        });
-        break;
-      case 'Unauthorized':
-        markAsLogoutState();
-        addToast({
-          message: '認証が切れました。再度ログインしてください。',
-          type: 'error',
-        });
-        $goto('/login');
-        break;
-      default:
-        addToast({
-          message: `${operation}に失敗しました。もう一度時間をおいて再読み込みしてください。`,
-          type: 'error',
-        });
-        break;
-    }
-  }
 
   async function fetchLogistics() {
     try {

--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -9,8 +9,8 @@
   import { CROP_UNITS_LABEL } from '../../../constants/product';
   import { ProductRepository, type TProduct } from '../../../models/Product';
   import { profile } from '../../../stores/Account';
-  import { markAsLogoutState } from '../../../stores/Login';
   import { addToast } from '../../../stores/Toast';
+  import { handleError } from '../../../utils/error-handle-helper';
 
   $: productRepository = new ProductRepository();
   $: canCanceled = false;
@@ -47,31 +47,6 @@
       $goto('/product');
     } catch (err) {
       handleError(err, '出品のとりやめ');
-    }
-  }
-
-  function handleError(err, operation: string) {
-    switch (err.error || err.message) {
-      case 'Bad Request':
-        addToast({
-          message: `${operation}に失敗しました。開発者へお問い合わせください。`,
-          type: 'error',
-        });
-        break;
-      case 'Unauthorized':
-        markAsLogoutState();
-        addToast({
-          message: '認証が切れました。再度ログインしてください。',
-          type: 'error',
-        });
-        $goto('/login');
-        break;
-      default:
-        addToast({
-          message: `${operation}に失敗しました。もう一度時間をおいて再読み込みしてください。`,
-          type: 'error',
-        });
-        break;
     }
   }
 

--- a/web/app/src/pages/product/_components/ProductForm.svelte
+++ b/web/app/src/pages/product/_components/ProductForm.svelte
@@ -7,7 +7,6 @@
   import { createField, createForm } from 'felte';
   import CloseIcon from '../../../components/icon/CloseIcon.svelte';
   import { CROP_KINDS, CROP_KINDS_LABEL, CROP_UNITS, CROP_UNITS_LABEL, SHOCK_LEVEL } from '../../../constants/product';
-  import { ShowableError } from '../../../models/Error';
   import { addToast } from '../../../stores/Toast';
   import { encodeFileToBase64 } from '../../../utils/file';
   import type { TProductForm } from '../../../models/Product';
@@ -98,7 +97,10 @@
         onInput(await encodeFileToBase64(files[0]));
         onBlur();
       } catch {
-        throw new ShowableError('画像の読み込みに失敗しました。');
+        addToast({
+          message: '画像の読み込みに失敗しました。',
+          type: 'error',
+        });
       }
     }
   }

--- a/web/app/src/pages/product/index.svelte
+++ b/web/app/src/pages/product/index.svelte
@@ -8,8 +8,7 @@
   import { CROP_UNITS_LABEL } from '../../constants/product';
   import { ProductRepository, type TProduct } from '../../models/Product';
   import { profile } from '../../stores/Account';
-  import { markAsLogoutState } from '../../stores/Login';
-  import { addToast } from '../../stores/Toast';
+  import { handleError } from '../../utils/error-handle-helper';
 
   $: productRepository = new ProductRepository();
 
@@ -18,22 +17,7 @@
       const products = await productRepository.all();
       return products;
     } catch (err) {
-      switch (err.error || err.message) {
-        case 'Unauthorized':
-          markAsLogoutState();
-          addToast({
-            message: '認証が切れました。再度ログインしてください。',
-            type: 'error',
-          });
-          $goto('/login');
-          break;
-        default:
-          addToast({
-            message: '商品の取得に失敗しました。もう一度時間をおいて再読み込みしてください。',
-            type: 'error',
-          });
-          break;
-      }
+      handleError(err);
       return [];
     }
   }

--- a/web/app/src/pages/product/new.svelte
+++ b/web/app/src/pages/product/new.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { goto } from '@roxi/routify';
   import { ProductRepository, type TProductForm } from '../../models/Product';
-  import { markAsLogoutState } from '../../stores/Login';
   import { addToast } from '../../stores/Toast';
+  import { handleError } from '../../utils/error-handle-helper';
   import ProductForm from './_components/ProductForm.svelte';
 
   $: productRepository = new ProductRepository();
@@ -17,22 +17,7 @@
         $goto('./');
       })
       .catch((err) => {
-        switch (err.error || err.message) {
-          case 'Unauthorized':
-            markAsLogoutState();
-            addToast({
-              message: '認証が切れました。再度ログインしてください。',
-              type: 'error',
-            });
-            $goto('/login');
-            break;
-          default:
-            addToast({
-              message: '商品の作成に失敗しました。もう一度時間をおいて再度試してください。',
-              type: 'error',
-            });
-            break;
-        }
+        handleError(err);
       });
   }
 </script>

--- a/web/app/src/pages/reservation/[id]/index.svelte
+++ b/web/app/src/pages/reservation/[id]/index.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
-  import { goto, params } from '@roxi/routify';
+  import { params } from '@roxi/routify';
   import Button from '@smui/button';
   import CircularProgress from '@smui/circular-progress';
-  import Dialog, { Title, Content, Actions } from '@smui/dialog';
-  import List, { Item, Graphic, Text } from '@smui/list';
   import Paper from '@smui/paper';
-  import Radio from '@smui/radio';
   import dayjs from 'dayjs';
   import StatusLabel from '.././_components/StatusLabel.svelte';
   import { CROP_UNITS_LABEL } from '../../../constants/product';
   import { ReservationRepository, type TReservation, RESERVATION_STATUS } from '../../../models/Reservation';
-  import { AccountService } from '../../../services/AccountService';
   import { profile } from '../../../stores/Account';
-  import { markAsLogoutState } from '../../../stores/Login';
-  import { addToast } from '../../../stores/Toast';
+  import { handleError } from '../../../utils/error-handle-helper';
+  import CancelConfirmDialog from '../_components/CancelConfirmDialog.svelte';
+  import KeptConfirmDialog from '../_components/KeptConfirmDialog.svelte';
+  import PackedWizardDialog from '../_components/PackedWizardDialog.svelte';
+  import ReceivedConfirmDialog from '../_components/ReceivedConfirmDialog.svelte';
 
   $: reservationRepository = new ReservationRepository();
 
@@ -49,113 +48,7 @@
   let isOpenPackedConfirmDialog = false;
   let isOpenKeptConfirmDialog = false;
   let isOpenReceivedConfirmDialog = false;
-  let isOpenCanceledConfirmDialog = false;
-
-  let selectedShipperId = '';
-
-  async function fetchLogistics() {
-    try {
-      const logistics = await new AccountService().getLogistics();
-      logistics.push($profile);
-      return Object.fromEntries(logistics.map(({ id, name }) => [id, name]));
-    } catch (err) {
-      handleError(err);
-      return [];
-    }
-  }
-
-  async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
-    switch (e.detail.action) {
-      case 'packed':
-        await packed();
-        break;
-      case 'kept':
-        await kept();
-        break;
-      case 'received':
-        await received();
-        break;
-      case 'canceled':
-        await canceled();
-        break;
-      default:
-        // NOP
-        break;
-    }
-  }
-
-  async function packed() {
-    try {
-      const updateReservationData = await reservationRepository.packed($params.id, { shipperId: selectedShipperId });
-      reservationStatus = updateReservationData.status;
-      addToast({
-        message: '予約作物の出荷が完了しました。',
-      });
-    } catch (err) {
-      handleError(err);
-    }
-  }
-
-  async function kept() {
-    try {
-      const updateReservationData = await reservationRepository.kept($params.id);
-      reservationStatus = updateReservationData.status;
-      addToast({
-        message: '予約作物を店舗で保管しています。',
-      });
-    } catch (err) {
-      handleError(err);
-    }
-  }
-
-  async function received() {
-    try {
-      const updateReservationData = await reservationRepository.received($params.id);
-      reservationStatus = updateReservationData.status;
-      addToast({
-        message: '予約作物を受取りました。',
-      });
-    } catch (err) {
-      handleError(err);
-    }
-  }
-
-  async function canceled() {
-    try {
-      const updateReservationData = await reservationRepository.canceled($params.id);
-      reservationStatus = updateReservationData.status;
-      addToast({
-        message: '予約を取り消しました。',
-      });
-    } catch (err) {
-      handleError(err);
-    }
-  }
-
-  function handleError(err) {
-    switch (err.error || err.message) {
-      case 'Bad Request':
-        addToast({
-          message: '予約の更新に失敗しました。開発者へお問い合わせください。',
-          type: 'error',
-        });
-        break;
-      case 'Unauthorized':
-        markAsLogoutState();
-        addToast({
-          message: '認証が切れました。再度ログインしてください。',
-          type: 'error',
-        });
-        $goto('/login');
-        break;
-      default:
-        addToast({
-          message: '予約の更新に失敗しました。もう一度時間をおいて再読み込みしてください。',
-          type: 'error',
-        });
-        break;
-    }
-  }
+  let isOpenCancelConfirmDialog = false;
 </script>
 
 {#await fetchReservationProducts()}
@@ -258,43 +151,7 @@
         >
           <p class="text-lg font-bold">出荷</p>
         </Button>
-        <Dialog selection bind:open={isOpenPackedConfirmDialog} on:SMUIDialog:closed={onDialogClosedHandle}>
-          <Title>配送者を選択して出荷しますか？</Title>
-          <Content>
-            {#await fetchLogistics()}
-              <div style="display: flex; justify-content: center">
-                <CircularProgress style=" width: 32px;height: 160px;" indeterminate />
-              </div>
-            {:then logistics}
-              <div class="max-h-[300px]">
-                <List radioList>
-                  {#each Object.keys(logistics) as shipper}
-                    <Item>
-                      <Graphic>
-                        <Radio bind:group={selectedShipperId} value={shipper} />
-                      </Graphic>
-                      <Text>{logistics[shipper]}</Text>
-                    </Item>
-                  {/each}
-                </List>
-              </div>
-            {/await}
-          </Content>
-          <Actions>
-            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="outlined">
-              <p class="text-lg font-bold">キャンセル</p>
-            </Button>
-            <Button
-              class="w-[150px]  rounded-full px-4 py-2"
-              color="secondary"
-              variant="raised"
-              action="packed"
-              disabled={!selectedShipperId}
-            >
-              <p class="text-lg font-bold">出荷</p>
-            </Button>
-          </Actions>
-        </Dialog>
+        <PackedWizardDialog bind:open={isOpenPackedConfirmDialog} reservationId={$params.id} bind:reservationStatus />
       {/if}
       {#if canKept(reservationData)}
         <Button
@@ -305,17 +162,7 @@
         >
           <p class="text-lg font-bold">店舗預かり</p>
         </Button>
-        <Dialog selection bind:open={isOpenKeptConfirmDialog} on:SMUIDialog:closed={onDialogClosedHandle}>
-          <Title>店舗で作物を預かりましたか？</Title>
-          <Actions>
-            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="outlined">
-              <p class="text-lg font-bold">キャンセル</p>
-            </Button>
-            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="raised" action="kept">
-              <p class="text-lg font-bold">店舗預かり</p>
-            </Button>
-          </Actions>
-        </Dialog>
+        <KeptConfirmDialog bind:open={isOpenKeptConfirmDialog} reservationId={$params.id} bind:reservationStatus />
       {/if}
       {#if canReceived(reservationData)}
         <Button
@@ -326,17 +173,11 @@
         >
           <p class="text-lg font-bold">受取り</p>
         </Button>
-        <Dialog selection bind:open={isOpenReceivedConfirmDialog} on:SMUIDialog:closed={onDialogClosedHandle}>
-          <Title>作物を受取りましたか？</Title>
-          <Actions>
-            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="outlined">
-              <p class="text-lg font-bold">キャンセル</p>
-            </Button>
-            <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="raised" action="received">
-              <p class="text-lg font-bold">受取り</p>
-            </Button>
-          </Actions>
-        </Dialog>
+        <ReceivedConfirmDialog
+          bind:open={isOpenReceivedConfirmDialog}
+          reservationId={$params.id}
+          bind:reservationStatus
+        />
       {/if}
       {#if canEdit(reservationData)}
         <div>
@@ -349,21 +190,15 @@
             class="w-[150px] rounded-full px-4 py-2"
             color="secondary"
             variant="raised"
-            on:click={() => (isOpenCanceledConfirmDialog = true)}
+            on:click={() => (isOpenCancelConfirmDialog = true)}
           >
             <p class="text-lg font-bold">予約取り消し</p>
           </Button>
-          <Dialog selection bind:open={isOpenCanceledConfirmDialog} on:SMUIDialog:closed={onDialogClosedHandle}>
-            <Title>予約を取り消しますか？</Title>
-            <Actions>
-              <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="outlined">
-                <p class="text-lg font-bold">キャンセル</p>
-              </Button>
-              <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="raised" action="canceled">
-                <p class="text-lg font-bold">取り消し</p>
-              </Button>
-            </Actions>
-          </Dialog>
+          <CancelConfirmDialog
+            bind:open={isOpenCancelConfirmDialog}
+            reservationId={$params.id}
+            bind:reservationStatus
+          />
         </div>
       {/if}
     </div>

--- a/web/app/src/pages/reservation/_components/CancelConfirmDialog.svelte
+++ b/web/app/src/pages/reservation/_components/CancelConfirmDialog.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { ReservationRepository, type TReservation } from '../../../models/Reservation';
+  import { addToast } from '../../../stores/Toast';
+  import { handleError } from '../../../utils/error-handle-helper';
+  import ConfirmDialog from './ConfirmDialog.svelte';
+
+  export let open: boolean;
+  export let reservationId: string;
+  export let reservationStatus: TReservation['status'];
+
+  $: reservationRepository = new ReservationRepository();
+
+  async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
+    switch (e.detail.action) {
+      case 'canceled':
+        await canceled();
+        break;
+      default:
+        // NOP
+        break;
+    }
+  }
+
+  async function canceled() {
+    try {
+      const updateReservationData = await reservationRepository.canceled(reservationId);
+      reservationStatus = updateReservationData.status;
+      addToast({
+        message: '予約を取り消しました。',
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  }
+</script>
+
+<ConfirmDialog
+  {open}
+  closedAction={onDialogClosedHandle}
+  title="予約を取り消しますか？"
+  negativeButtonName="キャンセル"
+  negativeButtonAction=""
+  positiveButtonName="取り消し"
+  positiveButtonAction="canceled"
+/>

--- a/web/app/src/pages/reservation/_components/ConfirmDialog.svelte
+++ b/web/app/src/pages/reservation/_components/ConfirmDialog.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import Button from '@smui/button';
+  import Dialog, { Title, Actions } from '@smui/dialog';
+
+  export let open: boolean;
+  export let closedAction: (e: CustomEvent<{ action: string }>) => Promise<void>;
+  export let title: string;
+  export let negativeButtonName: string;
+  export let negativeButtonAction: string;
+  export let positiveButtonName: string;
+  export let positiveButtonAction: string;
+</script>
+
+<Dialog selection bind:open on:SMUIDialog:closed={closedAction}>
+  <Title>{title}</Title>
+  <Actions>
+    <Button
+      class="w-[150px]  rounded-full px-4 py-2"
+      color="secondary"
+      variant="outlined"
+      action={negativeButtonAction}
+    >
+      <p class="text-lg font-bold">{negativeButtonName}</p>
+    </Button>
+    <Button class="w-[150px]  rounded-full px-4 py-2" color="secondary" variant="raised" action={positiveButtonAction}>
+      <p class="text-lg font-bold">{positiveButtonName}</p>
+    </Button>
+  </Actions>
+</Dialog>

--- a/web/app/src/pages/reservation/_components/KeptConfirmDialog.svelte
+++ b/web/app/src/pages/reservation/_components/KeptConfirmDialog.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { ReservationRepository, type TReservation } from '../../../models/Reservation';
+  import { addToast } from '../../../stores/Toast';
+  import { handleError } from '../../../utils/error-handle-helper';
+  import ConfirmDialog from './ConfirmDialog.svelte';
+
+  export let open: boolean;
+  export let reservationId: string;
+  export let reservationStatus: TReservation['status'];
+
+  $: reservationRepository = new ReservationRepository();
+
+  async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
+    switch (e.detail.action) {
+      case 'kept':
+        await kept();
+        break;
+      default:
+        // NOP
+        break;
+    }
+  }
+
+  async function kept() {
+    try {
+      const updateReservationData = await reservationRepository.kept(reservationId);
+      reservationStatus = updateReservationData.status;
+      addToast({
+        message: '予約作物を店舗で保管しています。',
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  }
+</script>
+
+<ConfirmDialog
+  {open}
+  closedAction={onDialogClosedHandle}
+  title="店舗で作物を預かりましたか？"
+  negativeButtonName="キャンセル"
+  negativeButtonAction=""
+  positiveButtonName="店舗預かり"
+  positiveButtonAction="kept"
+/>

--- a/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
+++ b/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
@@ -1,0 +1,206 @@
+<script lang="ts">
+  import Button from '@smui/button';
+  import CircularProgress from '@smui/circular-progress';
+  import Dialog, { Title, Content, Actions } from '@smui/dialog';
+  import List, { Item, Graphic, Text } from '@smui/list';
+  import Radio from '@smui/radio';
+  import { Steps } from 'svelte-steps';
+  import { USER_ATTRIBUTE } from '../../../constants/account';
+  import { DELIVERY_TYPE } from '../../../constants/logistics';
+  import { ReservationRepository, type TReservation } from '../../../models/Reservation';
+  import { AccountService } from '../../../services/AccountService';
+  import { profile } from '../../../stores/Account';
+  import { addToast } from '../../../stores/Toast';
+  import { handleError } from '../../../utils/error-handle-helper';
+
+  export let open: boolean;
+  export let reservationId: string;
+  export let reservationStatus: TReservation['status'];
+
+  $: reservationRepository = new ReservationRepository();
+
+  const PACKED_STEPS = {
+    select_shipper: {
+      text: '配送者選択',
+      index: 0,
+    },
+    select_trip: {
+      text: '配送便選択',
+      index: 1,
+    },
+    confirm_packed: {
+      text: '出荷確認',
+      index: 2,
+    },
+  };
+  let currentStep = PACKED_STEPS.select_shipper.index;
+  let steps = [
+    { text: PACKED_STEPS.select_shipper.text },
+    { text: PACKED_STEPS.select_trip.text },
+    { text: PACKED_STEPS.confirm_packed.text },
+  ];
+
+  let selectedShipperId = '';
+  let selectedTripId = '';
+
+  let logistics = [];
+
+  async function fetchLogistics(): Promise<{ [k: string]: string }> {
+    try {
+      logistics = await new AccountService().getLogistics();
+      logistics.push($profile);
+      return Object.fromEntries(logistics.map(({ id, name }) => [id, name]));
+    } catch (err) {
+      handleError(err);
+      return {};
+    }
+  }
+
+  $: isTripSelectionRequired(selectedShipperId);
+
+  function isTripSelectionRequired(selectedShipperId) {
+    const selectedShipper = logistics.filter((user) => user.id === selectedShipperId)[0];
+    return (
+      selectedShipper &&
+      selectedShipper.attribute === USER_ATTRIBUTE.logistics &&
+      selectedShipper.logisticsSettingForLogistics.deliveryType === DELIVERY_TYPE.route
+    );
+  }
+
+  async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
+    switch (e.detail.action) {
+      case 'packed':
+        await packed();
+        break;
+      default:
+        // NOP
+        break;
+    }
+  }
+
+  async function packed() {
+    try {
+      const updateReservationData = await reservationRepository.packed(reservationId, { shipperId: selectedShipperId });
+      reservationStatus = updateReservationData.status;
+      addToast({
+        message: '予約作物の出荷が完了しました。',
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  }
+</script>
+
+<Dialog selection bind:open on:SMUIDialog:closed={onDialogClosedHandle}>
+  <Title>
+    <div class="text-xs">
+      <Steps {steps} current={currentStep} size="2rem" clickable={false} />
+    </div>
+    <div class="mt-5 text-sm">
+      {#if PACKED_STEPS.select_shipper.index === currentStep}
+        <p>配送者を選択してください</p>
+      {:else if PACKED_STEPS.select_trip.index === currentStep}
+        {#if isTripSelectionRequired(selectedShipperId)}
+          <p>配送する便を選択してください。</p>
+        {:else}
+          <p>配送便の選択はありません。次へ進んでください。</p>
+        {/if}
+      {:else if PACKED_STEPS.confirm_packed.index === currentStep}
+        <p>出荷してもよろしいですか？</p>
+      {/if}
+    </div>
+  </Title>
+  <Content>
+    <div class="max-h-[300px]">
+      {#if open}
+        {#if PACKED_STEPS.select_shipper.index === currentStep}
+          {#await fetchLogistics()}
+            <div style="display: flex; justify-content: center">
+              <CircularProgress style=" width: 32px;height: 160px;" indeterminate />
+            </div>
+          {:then logistics}
+            <List radioList>
+              {#each Object.keys(logistics) as shipper}
+                <Item>
+                  <Graphic>
+                    <Radio bind:group={selectedShipperId} value={shipper} />
+                  </Graphic>
+                  <Text>{logistics[shipper]}</Text>
+                </Item>
+              {/each}
+            </List>
+          {/await}
+        {:else if PACKED_STEPS.select_trip.index === currentStep}
+          <div />
+          {#if isTripSelectionRequired(selectedShipperId)}
+            <div />
+          {:else}
+            <div />
+          {/if}
+        {:else if PACKED_STEPS.confirm_packed.index === currentStep}
+          <div />
+        {/if}
+      {/if}
+    </div>
+  </Content>
+  <Actions>
+    {#if PACKED_STEPS.select_shipper.index === currentStep}
+      <Button
+        disabled={!selectedShipperId}
+        class="w-[100px]  rounded-full px-4 py-2"
+        color="secondary"
+        variant="raised"
+        on:click={() => (currentStep = PACKED_STEPS.select_trip.index)}
+      >
+        <p class="text-lg font-bold">次へ</p>
+      </Button>
+    {:else if PACKED_STEPS.select_trip.index === currentStep}
+      <Button
+        class="w-[100px]  rounded-full px-4 py-2"
+        color="secondary"
+        variant="outlined"
+        on:click={() => (currentStep = PACKED_STEPS.select_shipper.index)}
+      >
+        <p class="text-lg font-bold">前へ</p>
+      </Button>
+      {#if isTripSelectionRequired(selectedShipperId)}
+        <Button
+          disabled={!selectedTripId}
+          class="w-[100px]  rounded-full px-4 py-2"
+          color="secondary"
+          variant="raised"
+          on:click={() => (currentStep = PACKED_STEPS.confirm_packed.index)}
+        >
+          <p class="text-lg font-bold">次へ</p>
+        </Button>
+      {:else}
+        <Button
+          class="w-[100px]  rounded-full px-4 py-2"
+          color="secondary"
+          variant="raised"
+          on:click={() => (currentStep = PACKED_STEPS.confirm_packed.index)}
+        >
+          <p class="text-lg font-bold">次へ</p>
+        </Button>
+      {/if}
+    {:else if PACKED_STEPS.confirm_packed.index === currentStep}
+      <Button
+        class="w-[100px]  rounded-full px-4 py-2"
+        color="secondary"
+        variant="outlined"
+        on:click={() => (currentStep = PACKED_STEPS.select_trip.index)}
+      >
+        <p class="text-lg font-bold">前へ</p>
+      </Button>
+      <Button
+        class="w-[150px]  rounded-full px-4 py-2"
+        color="secondary"
+        variant="raised"
+        action="packed"
+        disabled={!selectedShipperId}
+      >
+        <p class="text-lg font-bold">出荷</p>
+      </Button>
+    {/if}
+  </Actions>
+</Dialog>

--- a/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
+++ b/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
@@ -5,8 +5,6 @@
   import List, { Item, Graphic, Text } from '@smui/list';
   import Radio from '@smui/radio';
   import { Steps } from 'svelte-steps';
-  import { USER_ATTRIBUTE } from '../../../constants/account';
-  import { DELIVERY_TYPE } from '../../../constants/logistics';
   import { ReservationRepository, type TReservation } from '../../../models/Reservation';
   import { AccountService } from '../../../services/AccountService';
   import { profile } from '../../../stores/Account';
@@ -59,12 +57,14 @@
   $: isTripSelectionRequired(selectedShipperId);
 
   function isTripSelectionRequired(selectedShipperId) {
-    const selectedShipper = logistics.filter((user) => user.id === selectedShipperId)[0];
-    return (
-      selectedShipper &&
-      selectedShipper.attribute === USER_ATTRIBUTE.logistics &&
-      selectedShipper.logisticsSettingForLogistics.deliveryType === DELIVERY_TYPE.route
-    );
+    // TODO: 配送便候補取得APIとの結合を後続のタスクで行うため、まだ巡回経路で集荷や配送を行う物流業者の場合でも配送便候補を選択せずに出荷できるようにしておく
+    // const selectedShipper = logistics.filter((user) => user.id === selectedShipperId)[0];
+    // return (
+    //   selectedShipper &&
+    //   selectedShipper.attribute === USER_ATTRIBUTE.logistics &&
+    //   selectedShipper.logisticsSettingForLogistics.deliveryType === DELIVERY_TYPE.route
+    // );
+    return false;
   }
 
   async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {

--- a/web/app/src/pages/reservation/_components/ReceivedConfirmDialog.svelte
+++ b/web/app/src/pages/reservation/_components/ReceivedConfirmDialog.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { ReservationRepository, type TReservation } from '../../../models/Reservation';
+  import { addToast } from '../../../stores/Toast';
+  import { handleError } from '../../../utils/error-handle-helper';
+  import ConfirmDialog from './ConfirmDialog.svelte';
+
+  export let open: boolean;
+  export let reservationId: string;
+  export let reservationStatus: TReservation['status'];
+
+  $: reservationRepository = new ReservationRepository();
+
+  async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
+    switch (e.detail.action) {
+      case 'received':
+        await received();
+        break;
+      default:
+        // NOP
+        break;
+    }
+  }
+  async function received() {
+    try {
+      const updateReservationData = await reservationRepository.received(reservationId);
+      reservationStatus = updateReservationData.status;
+      addToast({
+        message: '予約作物を受取りました。',
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  }
+</script>
+
+<ConfirmDialog
+  {open}
+  closedAction={onDialogClosedHandle}
+  title="作物を受取りましたか？"
+  negativeButtonName="キャンセル"
+  negativeButtonAction=""
+  positiveButtonName="受取り"
+  positiveButtonAction="received"
+/>

--- a/web/app/src/pages/reservation/_components/ReservationForm.svelte
+++ b/web/app/src/pages/reservation/_components/ReservationForm.svelte
@@ -10,8 +10,7 @@
   import { CROP_UNITS_LABEL } from '../../../constants/product';
   import { ProductRepository, type TProduct } from '../../../models/Product';
   import { AccountService } from '../../../services/AccountService';
-  import { markAsLogoutState } from '../../../stores/Login';
-  import { addToast } from '../../../stores/Toast';
+  import { handleError } from '../../../utils/error-handle-helper';
   import type { TReservationForm } from '../../../models/Reservation';
 
   export let onConfirm: (values: Required<TReservationForm>) => unknown;
@@ -34,22 +33,7 @@
       reservationRangeMax = selectedProduct.remaining > RESERVATION_MAX ? RESERVATION_MAX : selectedProduct.remaining;
       totalPrice = selectedProduct.unitPrice;
     } catch (err) {
-      switch (err.error || err.message) {
-        case 'Unauthorized':
-          markAsLogoutState();
-          addToast({
-            message: '認証が切れました。再度ログインしてください。',
-            type: 'error',
-          });
-          $goto('/login');
-          break;
-        default:
-          addToast({
-            message: '情報の取得に失敗しました。もう一度時間をおいて再読み込みしてください。',
-            type: 'error',
-          });
-          break;
-      }
+      handleError(err);
     }
   });
 

--- a/web/app/src/pages/reservation/index.svelte
+++ b/web/app/src/pages/reservation/index.svelte
@@ -6,8 +6,7 @@
   import { USER_ATTRIBUTE } from '../../constants/account';
   import { ReservationRepository, statusToText } from '../../models/Reservation';
   import { profile } from '../../stores/Account';
-  import { markAsLogoutState } from '../../stores/Login';
-  import { addToast } from '../../stores/Toast';
+  import { handleError } from '../../utils/error-handle-helper';
 
   $: reservationRepository = new ReservationRepository();
 
@@ -15,22 +14,7 @@
     try {
       return await reservationRepository.allReservations();
     } catch (err) {
-      switch (err.error || err.message) {
-        case 'Unauthorized':
-          markAsLogoutState();
-          addToast({
-            message: '認証が切れました。再度ログインしてください。',
-            type: 'error',
-          });
-          $goto('/login');
-          break;
-        default:
-          addToast({
-            message: '予約の取得に失敗しました。もう一度時間をおいて再読み込みしてください。',
-            type: 'error',
-          });
-          break;
-      }
+      handleError(err);
       return [];
     }
   }

--- a/web/app/src/pages/reservation/new.svelte
+++ b/web/app/src/pages/reservation/new.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { goto } from '@roxi/routify';
   import { ReservationRepository, type TReservationForm } from '../../models/Reservation';
-  import { markAsLogoutState } from '../../stores/Login';
   import { addToast } from '../../stores/Toast';
+  import { handleError } from '../../utils/error-handle-helper';
   import ReservationForm from './_components/ReservationForm.svelte';
 
   $: reservationRepository = new ReservationRepository();
@@ -17,22 +17,7 @@
         $goto('./');
       })
       .catch((err) => {
-        switch (err.error || err.message) {
-          case 'Unauthorized':
-            markAsLogoutState();
-            addToast({
-              message: '認証が切れました。再度ログインしてください。',
-              type: 'error',
-            });
-            $goto('/login');
-            break;
-          default:
-            addToast({
-              message: '予約に失敗しました。もう一度時間をおいて再度試してください。',
-              type: 'error',
-            });
-            break;
-        }
+        handleError(err);
       });
   }
 </script>

--- a/web/app/src/pages/signup/index.svelte
+++ b/web/app/src/pages/signup/index.svelte
@@ -14,10 +14,10 @@
     USER_ATTRIBUTE,
     USER_ATTRIBUTE_LABEL,
   } from '../../constants/account';
-  import { ShowableError } from '../../models/Error';
   import { AccountService } from '../../services/AccountService';
   import { isLoggedIn } from '../../stores/Login';
   import { addToast } from '../../stores/Toast';
+  import { handleError } from '../../utils/error-handle-helper';
   import { encodeFileToBase64 } from '../../utils/file';
 
   let email = '';
@@ -50,7 +50,10 @@
       try {
         image = await encodeFileToBase64(files[0]);
       } catch {
-        throw new ShowableError('画像の読み込みに失敗しました。');
+        addToast({
+          message: '画像の読み込みに失敗しました。',
+          type: 'error',
+        });
       }
     }
   }
@@ -87,10 +90,7 @@
           $goto('/login');
         })
         .catch((err) => {
-          addToast({
-            message: err.message,
-            type: 'error',
-          });
+          handleError(err);
         });
     }
   }

--- a/web/app/src/utils/error-handle-helper.ts
+++ b/web/app/src/utils/error-handle-helper.ts
@@ -23,7 +23,7 @@ export function handleError(err, operation = '操作') {
         message: '認証が切れました。再度ログインしてください。',
         type: 'error',
       });
-      $goto('/login');
+      window.location.replace('/login');
       break;
     default:
       addToast({

--- a/web/app/src/utils/error-handle-helper.ts
+++ b/web/app/src/utils/error-handle-helper.ts
@@ -1,0 +1,35 @@
+import { ShowableError } from '../models/Error';
+import { markAsLogoutState } from '../stores/Login';
+import { addToast } from '../stores/Toast';
+
+export function handleError(err, operation = '操作') {
+  if (err instanceof ShowableError) {
+    addToast({
+      message: err.message,
+      type: 'error',
+    });
+    return;
+  }
+  switch (err.error || err.message) {
+    case 'Bad Request':
+      addToast({
+        message: `${operation}に失敗しました。開発者へお問い合わせください。`,
+        type: 'error',
+      });
+      break;
+    case 'Unauthorized':
+      markAsLogoutState();
+      addToast({
+        message: '認証が切れました。再度ログインしてください。',
+        type: 'error',
+      });
+      $goto('/login');
+      break;
+    default:
+      addToast({
+        message: 'エラーが発生しました。時間をおいて再読み込みしてください。',
+        type: 'error',
+      });
+      break;
+  }
+}


### PR DESCRIPTION
# 概要

ウィザード形式で出荷ができるように対応した。
※配送便の選択による出荷に対応するための準備（松田さん作成APIとの結合）として、まずはAPIと結合しない部分を先にレビューに出します

# 制限事項

* 配送便候補取得APIとの結合を後続のタスクで行うため、まだ巡回経路で集荷や配送を行う物流業者の場合でも配送便候補を選択せずに出荷できるようにしている

# 変更点
  
* 出荷ダイアログの配送便選択に向けたウィザード化
* 予約でのステータス変更における各ダイアログのコンポーネント化による分離
* 共通的な通信時エラー処理の統一

# 動作確認内容

* 出荷ウィザードダイアログ
  * 生産者が出荷待ちの予約に対して出荷ボタンを押して出荷ウィザードが開くことを確認
  * 出荷ウィザードでどのような物流業者を選んでも、配送便の選択を行わず（制限事項を参照）に、出荷ができることを確認
* 店舗預かり確認ダイアログ
  * 引き渡し業者が集荷配送中の予約に対して、店舗預かりボタンを押して店舗預かり確認ダイアログが開くことを確認
  * 店舗預かり確認ダイアログで店舗預かりができることを確認
* 受取り確認ダイアログ
  * 消費者が店舗保管中の予約に対して、受取りボタンを押して受取り確認ダイアログが開くことを確認
  * 受取り確認ダイアログで受取りができることを確認
* 共通的な通信時エラー処理の統一
  *  ログイン中にローカルストレージのアクセストークン情報を削除して、任意の操作をしたときに、ログアウトしてログイン画面に遷移することを確認