### PR TITLE
物流便の選択による出荷ができる

### DIFF
--- a/server/app/src/reservation/reservation.service.ts
+++ b/server/app/src/reservation/reservation.service.ts
@@ -151,7 +151,6 @@ export class ReservationService {
       })
       .catch(() => {
         const shippingSchedule = new ShippingSchedule();
-        shippingSchedule.reservationIds = [];
         this.setShippingScheduleAttributes(dto, shippingSchedule, reservation);
         return shippingSchedule;
       });

--- a/server/app/src/reservation/reservation.service.ts
+++ b/server/app/src/reservation/reservation.service.ts
@@ -62,7 +62,15 @@ export class ReservationService {
     return await this.reservationRepository
       .findOne({
         where: { id },
-        relations: ['consumer', 'product', 'product.producer', 'shipper', 'receiveLocation'],
+        relations: [
+          'consumer',
+          'product',
+          'product.producer',
+          'product.producer.logisticsSettingForProducer',
+          'shipper',
+          'receiveLocation',
+          'receiveLocation.logisticsSettingForIntermediary',
+        ],
       })
       .then((reservation) => reservation.convertTReservation());
   }

--- a/server/app/src/reservation/reservation.service.ts
+++ b/server/app/src/reservation/reservation.service.ts
@@ -151,6 +151,7 @@ export class ReservationService {
       })
       .catch(() => {
         const shippingSchedule = new ShippingSchedule();
+        shippingSchedule.reservationIds = [];
         this.setShippingScheduleAttributes(dto, shippingSchedule, reservation);
         return shippingSchedule;
       });

--- a/web/app/src/models/Logistics.ts
+++ b/web/app/src/models/Logistics.ts
@@ -50,4 +50,10 @@ export class LogisticsRepository {
       body,
     });
   }
+
+  async getTripSuggestions(pickupStop: string, deliveryStop: string, count: number): Promise<Record<string, string>[]> {
+    return await baseAPI<Record<string, string>[]>({
+      endpoint: `${this.baseEndpoint}/tripsuggestions?pickup-stop=${pickupStop}&delivery-stop=${deliveryStop}&count=${count}`,
+    });
+  }
 }

--- a/web/app/src/models/Logistics.ts
+++ b/web/app/src/models/Logistics.ts
@@ -1,4 +1,5 @@
 import { baseAPI } from '../api/base';
+import type { TSuggestTrip as SuggestTrip } from './../../../../server/app/src/logistics/logistics.service';
 import type { CreateLogisticsSettingForIntermediaryDto } from './../../../../server/app/src/logistics/setting/intermediary/dto/create-setting.dto';
 import type { TLogisticsSettingForIntermediary } from './../../../../server/app/src/logistics/setting/intermediary/entities/setting.entity';
 import type { TLogisticsSettingForLogistics } from './../../../../server/app/src/logistics/setting/logistics/entities/setting.entity';
@@ -11,6 +12,7 @@ export type TLogisticsSetting = Jsonify<TLogisticsSettingForLogistics>;
 export type TIntermediarySetting = Jsonify<TLogisticsSettingForIntermediary>;
 export type TProducerSettingForm = Jsonify<CreateLogisticsSettingForProducerDto>;
 export type TIntermediarySettingForm = Jsonify<CreateLogisticsSettingForIntermediaryDto>;
+export type TSuggestTrip = Jsonify<SuggestTrip>;
 
 export class LogisticsRepository {
   get baseEndpoint(): string {

--- a/web/app/src/models/Logistics.ts
+++ b/web/app/src/models/Logistics.ts
@@ -53,9 +53,14 @@ export class LogisticsRepository {
     });
   }
 
-  async getTripSuggestions(pickupStop: string, deliveryStop: string, count: number): Promise<Record<string, string>[]> {
+  async getTripSuggestions(
+    logisticsId: string,
+    pickupStop: string,
+    deliveryStop: string,
+    count: number,
+  ): Promise<Record<string, string>[]> {
     return await baseAPI<Record<string, string>[]>({
-      endpoint: `${this.baseEndpoint}/tripsuggestions?pickup-stop=${pickupStop}&delivery-stop=${deliveryStop}&count=${count}`,
+      endpoint: `${this.baseEndpoint}/tripsuggestions?logisticsId=${logisticsId}&pickup-stop=${pickupStop}&delivery-stop=${deliveryStop}&count=${count}`,
     });
   }
 }

--- a/web/app/src/pages/reservation/[id]/index.svelte
+++ b/web/app/src/pages/reservation/[id]/index.svelte
@@ -151,7 +151,13 @@
         >
           <p class="text-lg font-bold">出荷</p>
         </Button>
-        <PackedWizardDialog bind:open={isOpenPackedConfirmDialog} reservationId={$params.id} bind:reservationStatus />
+        <PackedWizardDialog
+          bind:open={isOpenPackedConfirmDialog}
+          reservationId={$params.id}
+          bind:reservationStatus
+          pickupStop={'小町 バス停'}
+          deliveryStop={'北貞商店前 バス停'}
+        />
       {/if}
       {#if canKept(reservationData)}
         <Button

--- a/web/app/src/pages/reservation/[id]/index.svelte
+++ b/web/app/src/pages/reservation/[id]/index.svelte
@@ -155,8 +155,8 @@
           bind:open={isOpenPackedConfirmDialog}
           reservationId={$params.id}
           bind:reservationStatus
-          pickupStop={'小町 バス停'}
-          deliveryStop={'北貞商店前 バス停'}
+          pickupStop={reservationData.product.producer.logisticsSettingForProducer.stop}
+          deliveryStop={reservationData.receiveLocation.logisticsSettingForIntermediary.stop}
         />
       {/if}
       {#if canKept(reservationData)}

--- a/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
+++ b/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
@@ -81,6 +81,7 @@
     selectedTrip = null;
     try {
       suggestions = await new LogisticsRepository().getTripSuggestions(
+        selectedShipper.id,
         pickupStop,
         deliveryStop,
         MAX_SUGGEST_TRIP_COUNT,
@@ -117,23 +118,16 @@
       const packedData = selectedTrip
         ? {
             shipperId: selectedShipper.id,
-            // logisticsId と shipperId は同じなのでリクエストには不要ではないか？
             logisticsId: selectedShipper.id,
-            // クライアント側で改ざんできないようにバックエンド側で扱ってほしい
             logisticsName: selectedShipper.name,
             routeId: selectedTrip.routeId,
-            // クライアント側で改ざんできないようにバックエンド側で扱ってほしい
             routeName: selectedTrip.routeName,
             tripId: selectedTrip.tripId,
-            // クライアント側で改ざんできないようにバックエンド側で扱ってほしい
             tripName: selectedTrip.tripName,
             pickupStop,
-            // 取得した候補一覧ではpickupTimeをDBの値ではなく候補日時で扱えるようにしてほしい
             pickupTime: selectedTrip.pickupTime,
             deliveryStop,
-            // 取得した候補一覧にデータが含まれていないため仮でpickupTimeと同じにしておく
-            deliveryTime: selectedTrip.pickupTime,
-            // reservationIds はバックエンドで扱われていない
+            deliveryTime: selectedTrip.deliveryTime,
           }
         : { shipperId: selectedShipper.id };
       const updateReservationData = await reservationRepository.packed(reservationId, packedData);

--- a/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
+++ b/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
@@ -9,7 +9,7 @@
   import { Steps } from 'svelte-steps';
   import { USER_ATTRIBUTE } from '../../../constants/account';
   import { DELIVERY_TYPE } from '../../../constants/logistics';
-  import { LogisticsRepository } from '../../../models/Logistics';
+  import { LogisticsRepository, type TSuggestTrip } from '../../../models/Logistics';
   import { ReservationRepository, type TReservation } from '../../../models/Reservation';
   import { AccountService } from '../../../services/AccountService';
   import { profile } from '../../../stores/Account';
@@ -74,7 +74,7 @@
     );
   }
 
-  async function fetchTripSuggestions(): Promise<{ [k: string]: string }> {
+  async function fetchTripSuggestions(): Promise<TSuggestTrip[]> {
     try {
       const trips = await new LogisticsRepository().getTripSuggestions(
         pickupStop,
@@ -88,11 +88,11 @@
     }
   }
 
-  function selectTripStyle(e: Event, suggest: { [k: string]: string }) {
+  function selectTripStyle(e: Event, suggest: TSuggestTrip) {
     Array.prototype.forEach.call(document.getElementsByTagName('tr'), (element) => {
       element.style.backgroundColor = '#ffffff';
     });
-    e.currentTarget.style.backgroundColor = '#E0E0E0';
+    (e.currentTarget as HTMLElement).style.backgroundColor = '#E0E0E0';
     selectedTripId = suggest.tripId;
   }
 

--- a/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
+++ b/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
@@ -118,7 +118,6 @@
       const packedData = selectedTrip
         ? {
             shipperId: selectedShipper.id,
-            logisticsId: selectedShipper.id,
             logisticsName: selectedShipper.name,
             routeId: selectedTrip.routeId,
             routeName: selectedTrip.routeName,

--- a/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
+++ b/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
@@ -88,6 +88,14 @@
     }
   }
 
+  function selectTripStyle(e: Event, suggest: { [k: string]: string }) {
+    Array.prototype.forEach.call(document.getElementsByTagName('tr'), (element) => {
+      element.style.backgroundColor = '#ffffff';
+    });
+    e.currentTarget.style.backgroundColor = '#E0E0E0';
+    selectedTripId = suggest.tripId;
+  }
+
   async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
     switch (e.detail.action) {
       case 'packed':
@@ -136,8 +144,8 @@
       {#if open}
         {#if PACKED_STEPS.select_shipper.index === currentStep}
           {#await fetchLogistics()}
-            <div style="display: flex; justify-content: center">
-              <CircularProgress style=" width: 32px;height: 160px;" indeterminate />
+            <div class="flex justify-center">
+              <CircularProgress class="h-[160px] w-[32px]" indeterminate />
             </div>
           {:then logistics}
             <List radioList>
@@ -155,8 +163,8 @@
           <div />
           {#if isTripSelectionRequired(selectedShipperId)}
             {#await fetchTripSuggestions()}
-              <div style="display: flex; justify-content: center">
-                <CircularProgress style=" width: 32px;height: 160px;" indeterminate />
+              <div class="flex justify-center">
+                <CircularProgress class="h-[160px] w-[32px]" indeterminate />
               </div>
             {:then suggestions}
               <DataTable>
@@ -170,7 +178,7 @@
                 </Head>
                 {#each suggestions as suggest}
                   <Body class="cell">
-                    <Row>
+                    <Row on:click={(e) => selectTripStyle(e, suggest)}>
                       <Cell class="text-center">{suggest.routeName}</Cell>
                       <Cell class="text-center">{suggest.tripName}</Cell>
                       <Cell class="text-center">{suggest.pickupStop}</Cell>


### PR DESCRIPTION
# 概要

物流便の選択による出荷ができるように対応した。
#57 での制限解消

# 変更点
  
* 出荷ダイアログの配送便選択ウィザードにおいて、配送者に巡回経路で配送する物流業者を設定した場合に、配送便候補を選択できるように対応
* 配送便候補を選択した出荷ができるように対応

# 動作確認内容

* 出荷ウィザードダイアログ
  * 生産者が出荷待ちの予約に対して出荷ボタンを押して出荷ウィザードが開くことを確認
  * 出荷ウィザードで生産者自身を選択したとき、配送便の選択を行わずに、出荷ができることを確認
  * 出荷ウィザードで集荷先や配送先に直接伺う物流業者を選択したとき、配送便の選択を行わずに、出荷ができることを確認
  * 出荷ウィザードで巡回経路で配送する物流業者を選択したとき、その物流業者の配送便候補を表示して、配送便の候補から選択をして、出荷ができることを確認
 
* 予約一覧
  * 配送便候補を選択して出荷した予約には、その配送便の情報の列が表示されることを確認
