### PR TITLE
出荷ウィザードの配送便候補一覧表を画面幅があるときに横スクロールせずに表示できるように対応

### DIFF
--- a/server/app/src/logistics/logistics.service.ts
+++ b/server/app/src/logistics/logistics.service.ts
@@ -213,14 +213,17 @@ async function checkAvailableCapacityTrip(
   shippingScheduleRepository: Repository<ShippingSchedule>,
   checkDate: Date,
 ) {
-  const shippingScheduleReservations = await shippingScheduleRepository
+  const shippingScheduleReservationIds = await shippingScheduleRepository
     .findBy({
       tripId: suggestTrip.tripId,
       pickupTime: MoreThan(checkDate),
     })
-    .then((shippingSchedules) => shippingSchedules.map((shippingSchedule) => shippingSchedule.reservations));
+    .then((shippingSchedules) => shippingSchedules.map((shippingSchedule) => shippingSchedule.reservationIds));
 
-  const reservationCount = shippingScheduleReservations.reduce((acc, reservations) => acc + reservations.length, 0);
+  const reservationCount = shippingScheduleReservationIds.reduce(
+    (acc, reservationIds) => acc + reservationIds.length,
+    0,
+  );
 
   return reservationCount <= suggestTrip.capacity;
 }

--- a/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
+++ b/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
@@ -187,7 +187,7 @@
                 <CircularProgress class="h-[160px] w-[32px]" indeterminate />
               </div>
             {:then suggestions}
-              <DataTable>
+              <DataTable class="w-full">
                 <Head>
                   <Row>
                     <Cell class="text-center">路線</Cell>

--- a/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
+++ b/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
@@ -140,7 +140,7 @@
   }
 </script>
 
-<Dialog selection bind:open on:SMUIDialog:closed={onDialogClosedHandle}>
+<Dialog selection bind:open on:SMUIDialog:closed={onDialogClosedHandle} surface$style="max-width: calc(100vw - 32px);">
   <Title>
     <div class="text-xs">
       <Steps {steps} current={currentStep} size="2rem" clickable={false} />


### PR DESCRIPTION
# 概要

出荷ウィザードの配送便候補一覧表を画面幅があるときに横スクロールせずに表示できるように対応した
#60 でコメントをいただいた件の対応です

# 変更点
  
* 出荷ウィザードの配送便候補一覧表を画面幅があるときに横スクロールせずに表示できるように
* 配送便候補取得APIのcheckAvailableCapacityTripにおいてShippingScheduleにはreservationsというプロパティは存在せず、reservationIdsの誤りと思われるため修正した

# 動作確認内容

* 出荷ウィザードダイアログ
  * 出荷ウィザードで巡回経路で配送する物流業者を選択したとき、配送便候補一覧表の表示が、画面幅が広いときには横スクロールが表示されず、画面幅が狭いときには横スクロールが表示されるようになっていることを確認