### PR TITLE
出品内容編集機能を追加

### DIFF
--- a/server/app/package.json
+++ b/server/app/package.json
@@ -30,6 +30,7 @@
     "@nestjs/config": "^2.2.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/jwt": "^9.0.0",
+    "@nestjs/mapped-types": "^2.0.2",
     "@nestjs/passport": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/typeorm": "^9.0.1",

--- a/server/app/src/main.ts
+++ b/server/app/src/main.ts
@@ -9,7 +9,7 @@ async function bootstrap() {
     origin: '*',
     allowedHeaders:
       'Authorization, Access-Control-Allow-Headers, Access-Control-Allow-Origin, Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers',
-    methods: 'GET, POST, PUT, DELETE',
+    methods: 'GET, POST, PATCH, PUT, DELETE',
   });
   app.useGlobalPipes(new ValidationPipe());
   app.use(bodyParser.json({ limit: '10mb' }));

--- a/server/app/src/product/dto/update-product.dto.ts
+++ b/server/app/src/product/dto/update-product.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateProductDto } from './create-product.dto';
+
+export class UpdateProductDto extends PartialType(CreateProductDto) {}

--- a/server/app/src/product/entities/product.entity.ts
+++ b/server/app/src/product/entities/product.entity.ts
@@ -138,6 +138,7 @@ export type TProduct = Pick<
   | 'createdAt'
   | 'updatedAt'
   | 'deletedAt'
+  | 'shockLevel'
 > & {
   id: string;
   producer: Account;

--- a/server/app/src/product/product.controller.ts
+++ b/server/app/src/product/product.controller.ts
@@ -1,8 +1,9 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, UseGuards, Delete } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Patch, Post, UseGuards, Delete } from '@nestjs/common';
 import { Account } from 'src/account/entities/account.entity';
 import { GetAccount } from 'src/account/get-account.decorator';
 import { JwtAuthGuard } from 'src/account/jwt-auth.guard';
 import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
 import { TProduct } from './entities/product.entity';
 import { ProductService } from './product.service';
 
@@ -25,6 +26,15 @@ export class ProductController {
   @HttpCode(HttpStatus.CREATED)
   createProduct(@Body() createProductDto: CreateProductDto, @GetAccount() account: Account) {
     return this.productService.createProduct(createProductDto, account);
+  }
+
+  @Patch('/:productId')
+  async updateProduct(
+    @Body() updateProductDto: UpdateProductDto,
+    @GetAccount() account: Account,
+    @Param('productId') productId: string,
+  ) {
+    return this.productService.updateProduct(updateProductDto, account, productId);
   }
 
   @Delete('/:productId')

--- a/server/app/src/product/product.service.ts
+++ b/server/app/src/product/product.service.ts
@@ -55,13 +55,18 @@ export class ProductService {
   }
 
   async updateProduct(dto: UpdateProductDto, account: Account, productId: string): Promise<TProduct> {
-    if (account.attribute !== USER_ATTRIBUTE.producer) {
-      // 作成者以外の場合はエラーを表示。
-      throw new BadRequestException();
-    }
     const product = await this.productRepository.findOne({
       where: { id: productId },
     });
+
+    if (!product) {
+      throw new BadRequestException();
+    }
+    if (account.id !== product.producerId) {
+      // 作成者以外の場合はエラーを表示。
+      throw new BadRequestException();
+    }
+
     await ProductService.setProductAttributes(dto, product, account);
     await product.save();
 

--- a/server/app/src/product/product.service.ts
+++ b/server/app/src/product/product.service.ts
@@ -4,6 +4,7 @@ import * as dayjs from 'dayjs';
 import { Account, USER_ATTRIBUTE } from 'src/account/entities/account.entity';
 import { Repository, FindOptionsWhere } from 'typeorm';
 import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
 import { Product, TProduct } from './entities/product.entity';
 
 @Injectable()
@@ -44,7 +45,7 @@ export class ProductService {
     if (account.attribute === USER_ATTRIBUTE.producer) {
       producer = account;
     } else {
-      // 農家以外の場合はエラーを表示。
+      // 生産者以外の場合はエラーを表示。
       throw new BadRequestException();
     }
     await ProductService.setProductAttributes(dto, product, producer);
@@ -53,7 +54,25 @@ export class ProductService {
     return product.convertTProduct();
   }
 
-  private static async setProductAttributes(dto: CreateProductDto, product: Product, producer: Account) {
+  async updateProduct(dto: UpdateProductDto, account: Account, productId: string): Promise<TProduct> {
+    if (account.attribute !== USER_ATTRIBUTE.producer) {
+      // 作成者以外の場合はエラーを表示。
+      throw new BadRequestException();
+    }
+    const product = await this.productRepository.findOne({
+      where: { id: productId },
+    });
+    await ProductService.setProductAttributes(dto, product, account);
+    await product.save();
+
+    return product.convertTProduct();
+  }
+
+  private static async setProductAttributes(
+    dto: CreateProductDto | UpdateProductDto,
+    product: Product,
+    producer: Account,
+  ) {
     product.producerId = producer.id;
     product.name = dto.name;
     product.kinds = dto.kinds;

--- a/server/app/yarn.lock
+++ b/server/app/yarn.lock
@@ -740,6 +740,11 @@
     "@types/jsonwebtoken" "8.5.8"
     jsonwebtoken "8.5.1"
 
+"@nestjs/mapped-types@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/mapped-types/-/mapped-types-2.0.2.tgz#c8a090a8d22145b85ed977414c158534210f2e4f"
+  integrity sha512-V0izw6tWs6fTp9+KiiPUbGHWALy563Frn8X6Bm87ANLRuE46iuBMD5acKBDP5lKL/75QFvrzSJT7HkCbB0jTpg==
+
 "@nestjs/passport@^9.0.0":
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/@nestjs/passport/-/passport-9.0.0.tgz#0571bb08f8043456bc6df44cd4f59ca5f10c9b9f"

--- a/web/app/src/api/base.ts
+++ b/web/app/src/api/base.ts
@@ -10,7 +10,7 @@ export async function baseAPI<
   body,
 }: {
   endpoint: string;
-  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
   body?: B;
 }): Promise<T> {
   const controller = new AbortController();

--- a/web/app/src/models/Product.ts
+++ b/web/app/src/models/Product.ts
@@ -29,6 +29,14 @@ export class ProductRepository {
     });
   }
 
+  async update(id: string, body: TProductForm): Promise<TProduct> {
+    return await baseAPI<TProduct>({
+      endpoint: `${this.baseEndpoint}/${id}`,
+      method: 'PATCH',
+      body,
+    });
+  }
+
   async canceled(id: string): Promise<TProduct> {
     return await baseAPI<TProduct>({
       endpoint: `${this.baseEndpoint}/${id}`,

--- a/web/app/src/pages/product/[id]/edit.svelte
+++ b/web/app/src/pages/product/[id]/edit.svelte
@@ -3,7 +3,7 @@
   import CircularProgress from '@smui/circular-progress';
   import { ProductRepository, type TProduct, type TProductForm } from '../../../models/Product';
   import { addToast } from '../../../stores/Toast';
-  import { markAsLogoutState } from './../../../stores/Login';
+  import { handleError } from '../../../utils/error-handle-helper';
   import ProductForm from './../_components/ProductForm.svelte';
 
   $: productRepository = new ProductRepository();
@@ -12,52 +12,22 @@
     try {
       return await productRepository.findOne($params.id);
     } catch (err) {
-      switch (err.error || err.message) {
-        case 'Unauthorized':
-          markAsLogoutState();
-          addToast({
-            message: '認証が切れました。再度ログインしてください。',
-            type: 'error',
-          });
-          $goto('/login');
-          break;
-        default:
-          addToast({
-            message: '商品の取得に失敗しました。もう一度時間をおいて再読み込みしてください。',
-            type: 'error',
-          });
-          break;
-      }
-      return null;
+      handleError(err, '商品の取得');
     }
   }
 
   async function onConfirm(values: Required<TProductForm>) {
+    const operation = '商品の編集';
     await productRepository
       .update($params.id, { ...values })
       .then(() => {
         addToast({
-          message: '商品の編集に成功しました。',
+          message: `${operation}に成功しました。`,
         });
         $goto('./../');
       })
       .catch((err) => {
-        switch (err.error || err.message) {
-          case 'Unauthorized':
-            markAsLogoutState();
-            addToast({
-              message: '認証が切れました。再度ログインしてください。',
-              type: 'error',
-            });
-            $goto('/login');
-            break;
-          default:
-            addToast({
-              message: '商品の編集に失敗しました。もう一度時間をおいて再度試してください。',
-              type: 'error',
-            });
-            break;
-        }
+        handleError(err, operation);
       });
   }
 </script>

--- a/web/app/src/pages/product/[id]/edit.svelte
+++ b/web/app/src/pages/product/[id]/edit.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { goto, params } from '@roxi/routify';
+  import CircularProgress from '@smui/circular-progress';
+  import { ProductRepository, type TProduct, type TProductForm } from '../../../models/Product';
+  import { addToast } from '../../../stores/Toast';
+  import { markAsLogoutState } from './../../../stores/Login';
+  import ProductForm from './../_components/ProductForm.svelte';
+
+  $: productRepository = new ProductRepository();
+
+  async function fetchProduct(): Promise<TProduct> {
+    try {
+      return await productRepository.findOne($params.id);
+    } catch (err) {
+      switch (err.error || err.message) {
+        case 'Unauthorized':
+          markAsLogoutState();
+          addToast({
+            message: '認証が切れました。再度ログインしてください。',
+            type: 'error',
+          });
+          $goto('/login');
+          break;
+        default:
+          addToast({
+            message: '商品の取得に失敗しました。もう一度時間をおいて再読み込みしてください。',
+            type: 'error',
+          });
+          break;
+      }
+      return null;
+    }
+  }
+
+  async function onConfirm(values: Required<TProductForm>) {
+    await productRepository
+      .update($params.id, { ...values })
+      .then(() => {
+        addToast({
+          message: '商品の編集に成功しました。',
+        });
+        $goto('./../');
+      })
+      .catch((err) => {
+        switch (err.error || err.message) {
+          case 'Unauthorized':
+            markAsLogoutState();
+            addToast({
+              message: '認証が切れました。再度ログインしてください。',
+              type: 'error',
+            });
+            $goto('/login');
+            break;
+          default:
+            addToast({
+              message: '商品の編集に失敗しました。もう一度時間をおいて再度試してください。',
+              type: 'error',
+            });
+            break;
+        }
+      });
+  }
+</script>
+
+{#await fetchProduct()}
+  <div class="flex justify-center">
+    <CircularProgress class="h-40 w-8" indeterminate />
+  </div>
+{:then product}
+  <div>
+    <ProductForm pageType="edit" {onConfirm} {product} />
+  </div>
+{/await}

--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -123,7 +123,7 @@
           <p class="black">予約</p>
         </Button>
       </div>
-    {:else if $profile.attribute === USER_ATTRIBUTE.producer}
+    {:else if $profile.attribute === USER_ATTRIBUTE.producer && !isOutOfStock(product)}
       <div class="flex justify-center">
         <Button
           variant="raised"

--- a/web/app/src/pages/product/[id]/index.svelte
+++ b/web/app/src/pages/product/[id]/index.svelte
@@ -148,6 +148,17 @@
           <p class="black">予約</p>
         </Button>
       </div>
+    {:else if $profile.attribute === USER_ATTRIBUTE.producer}
+      <div class="flex justify-center">
+        <Button
+          variant="raised"
+          class="mt-10 w-[150px] rounded-full px-4 py-2"
+          color="secondary"
+          on:click={$goto('../../product/:id/edit', { id: $params.id })}
+        >
+          <p class="black">編集</p>
+        </Button>
+      </div>
     {/if}
 
     {#if $profile.attribute === USER_ATTRIBUTE.producer && canCanceled}

--- a/web/app/src/pages/product/_components/ProductForm.svelte
+++ b/web/app/src/pages/product/_components/ProductForm.svelte
@@ -28,7 +28,7 @@
   const END_AT_MIN_DATE_TIME = START_DEFAULT_DATE_TIME.add(1, 'day');
   const END_AT_MAX_DATE_TIME = START_DEFAULT_DATE_TIME.add(30, 'day');
 
-  const DATE_FORMAT = 'YYYY-MM-DDThh:mm';
+  const DATE_FORMAT = 'YYYY-MM-DDTHH:mm';
 
   const FILE_LIMIT_SIZE = 5 * 1024 * 1024;
 

--- a/web/app/src/pages/product/_components/ProductForm.svelte
+++ b/web/app/src/pages/product/_components/ProductForm.svelte
@@ -17,7 +17,7 @@
   import { ShowableError } from '../../../models/Error';
   import { addToast } from '../../../stores/Toast';
   import { encodeFileToBase64 } from '../../../utils/file';
-  import type { TProductForm } from '../../../models/Product';
+  import type { TProductForm, TProduct } from '../../../models/Product';
 
   const START_DEFAULT_DATE_TIME = new Date();
   START_DEFAULT_DATE_TIME.setHours(0);
@@ -54,36 +54,37 @@
 
   export let onConfirm: (values: Required<TProductForm>) => unknown;
 
-  const initialValues = {
-    name: '',
-    kinds: CROP_KINDS.vegetables,
-    description: '',
-    startAt: START_DEFAULT_DATE_TIME.toISOString().slice(0, 16),
-    endAt: END_DEFAULT_DATE_TIME.toISOString().slice(0, 16),
-    unit: CROP_UNITS.gram,
-    unitQuantity: 1,
-    unitPrice: 0,
-    image: '',
-    quantity: 1,
-    shockLevel: SHOCK_LEVEL.strong,
-  };
-
+  export let product: TProduct | undefined = undefined;
+  export let pageType: 'new' | 'edit';
   const { form, data } = createForm({
-    initialValues,
+    initialValues: {
+      ...product,
+      name: product?.name || '',
+      kinds: product?.kinds || CROP_KINDS.vegetables,
+      description: product?.description || '',
+      startAt: product?.startAt || START_DEFAULT_DATE_TIME.toISOString().slice(0, 16),
+      endAt: product?.endAt || END_DEFAULT_DATE_TIME.toISOString().slice(0, 16),
+      unit: product?.unit || CROP_UNITS.gram,
+      unitQuantity: product?.unitQuantity || 1,
+      unitPrice: product?.unitPrice || 0,
+      image: product?.image || '',
+      quantity: product?.quantity || 1,
+      shockLevel: product?.shockLevel || SHOCK_LEVEL.strong,
+    },
     onSubmit: async (values) => {
       await onConfirm({
         ...values,
-        name: name,
-        kinds: kinds,
-        description: description,
-        startAt: startAt,
-        endAt: endAt,
-        unit: unit,
-        unitQuantity: Number(unitQuantity),
-        unitPrice: Number(unitPrice),
+        name: $data.name,
+        kinds: $data.kinds,
+        description: $data.description,
+        startAt: $data.startAt,
+        endAt: $data.endAt,
+        unit: $data.unit,
+        unitQuantity: Number($data.unitQuantity),
+        unitPrice: Number($data.unitPrice),
         image: $data.image,
-        quantity: Number(quantity),
-        shockLevel: Number(shockLevel),
+        quantity: Number($data.quantity),
+        shockLevel: Number($data.shockLevel),
       });
     },
   });
@@ -114,17 +115,6 @@
     onInput('');
     onBlur();
   }
-
-  let name = '';
-  let kinds = CROP_KINDS.vegetables;
-  let description = '';
-  let startAt = START_DEFAULT_DATE_TIME.toISOString().slice(0, 16);
-  let endAt = END_DEFAULT_DATE_TIME.toISOString().slice(0, 16);
-  let unit = CROP_UNITS.gram;
-  let unitQuantity = 1;
-  let unitPrice = 0;
-  let quantity = 1;
-  let shockLevel = SHOCK_LEVEL.strong;
 </script>
 
 <div>
@@ -138,7 +128,7 @@
         <Textfield
           class="m-3 w-[300px]"
           label="作物名"
-          bind:value={name}
+          bind:value={$data.name}
           required
           type={'text'}
           input$maxlength={30}
@@ -147,7 +137,7 @@
       </div>
 
       <div>
-        <Select class="m-3 w-[300px]" variant="standard" label="作物の種類" bind:value={kinds} required>
+        <Select class="m-3 w-[300px]" variant="standard" label="作物の種類" bind:value={$data.kinds} required>
           {#each Object.keys(CROP_KINDS) as kind}
             <Option value={CROP_KINDS[kind]}>{CROP_KINDS_LABEL[kind]}</Option>
           {/each}
@@ -158,7 +148,7 @@
         <div class="label required input-title text-text-lightGray">説明</div>
         <Textfield
           class="w-[300px] sm:w-[300px] md:w-[600px]"
-          bind:value={description}
+          bind:value={$data.description}
           textarea
           input$maxlength={500}
           input$placeholder="例）甘くて美味しい、真っ赤な苺です。"
@@ -171,7 +161,7 @@
           class="m-3 w-[150px]"
           variant="standard"
           label="開始"
-          bind:value={startAt}
+          bind:value={$data.startAt}
           type="datetime-local"
           required
           input$min={START_AT_MIN_DATE_TIME.toISOString().slice(0, 16)}
@@ -183,7 +173,7 @@
           class="m-3 w-[150px]"
           variant="standard"
           label="終了"
-          bind:value={endAt}
+          bind:value={$data.endAt}
           type="datetime-local"
           required
           input$min={END_AT_MIN_DATE_TIME.toISOString().slice(0, 16)}
@@ -197,13 +187,13 @@
         <Textfield
           class="m-3 w-[100px]"
           label="単位数量"
-          bind:value={unitQuantity}
+          bind:value={$data.unitQuantity}
           required
           type={'number'}
           input$min={0}
           input$max={99999}
         />
-        <Select class="m-3 w-[100px]" label="単位" variant="standard" bind:value={unit} required>
+        <Select class="m-3 w-[100px]" label="単位" variant="standard" bind:value={$data.unit} required>
           {#each Object.keys(CROP_UNITS) as kind}
             <Option value={CROP_UNITS[kind]}>{CROP_UNITS_LABEL[kind]}</Option>
           {/each}
@@ -215,7 +205,7 @@
         <Textfield
           class="m-3 w-[150px]"
           label="金額"
-          bind:value={unitPrice}
+          bind:value={$data.unitPrice}
           required
           type={'number'}
           suffix="円"
@@ -229,7 +219,7 @@
         <Textfield
           class="ml-3 w-[150px]"
           label="数量"
-          bind:value={quantity}
+          bind:value={$data.quantity}
           required
           type={'number'}
           suffix="点"
@@ -278,7 +268,7 @@
       </h1>
 
       <div>
-        <Select class="m-3 w-[300px]" variant="standard" label="衝撃" bind:value={shockLevel} required>
+        <Select class="m-3 w-[300px]" variant="standard" label="衝撃" bind:value={$data.shockLevel} required>
           {#each Object.keys(SHOCK_LEVEL) as shockLevel}
             <Option value={SHOCK_LEVEL[shockLevel]}>{SHOCK_LEVEL_LABEL[shockLevel]}</Option>
           {/each}
@@ -298,7 +288,7 @@
       </Button>
 
       <Button variant="raised" class="mt-10 w-[150px] rounded-full px-4 py-2" color="secondary" type="submit">
-        <p class="black">出品</p>
+        <p class="black">{pageType === 'new' ? '出品' : '編集'}</p>
       </Button>
     </div>
   </form>

--- a/web/app/src/pages/product/_components/ProductForm.svelte
+++ b/web/app/src/pages/product/_components/ProductForm.svelte
@@ -4,6 +4,7 @@
   import IconButton from '@smui/icon-button';
   import Select, { Option } from '@smui/select';
   import Textfield from '@smui/textfield';
+  import dayjs from 'dayjs';
   import { createField, createForm } from 'felte';
   import CloseIcon from '../../../components/icon/CloseIcon.svelte';
   import {
@@ -18,30 +19,18 @@
   import { encodeFileToBase64 } from '../../../utils/file';
   import type { TProductForm, TProduct } from '../../../models/Product';
 
-  const START_DEFAULT_DATE_TIME = new Date();
-  START_DEFAULT_DATE_TIME.setHours(0);
-  START_DEFAULT_DATE_TIME.setMinutes(0);
-  const START_AT_MIN_DATE_TIME = new Date();
-  START_AT_MIN_DATE_TIME.setHours(0);
-  START_AT_MIN_DATE_TIME.setMinutes(0);
-  const START_AT_MAX_DATE_TIME = new Date();
-  START_AT_MAX_DATE_TIME.setMonth(START_AT_MAX_DATE_TIME.getMonth() + 1);
-  START_AT_MAX_DATE_TIME.setDate(START_AT_MAX_DATE_TIME.getDate() - 1);
-  START_AT_MAX_DATE_TIME.setHours(0);
-  START_AT_MAX_DATE_TIME.setMinutes(0);
+  const START_DEFAULT_DATE_TIME = dayjs().minute(0);
+  const START_AT_MIN_DATE_TIME = START_DEFAULT_DATE_TIME;
+  // 終了日は開始日の翌日以降 && 開始日と終了日が30日以内 を満たすには 開始日の上限が+29日である必要あり
+  const START_AT_MAX_DATE_TIME = START_DEFAULT_DATE_TIME.add(29, 'day');
 
-  const END_DEFAULT_DATE_TIME = new Date();
-  END_DEFAULT_DATE_TIME.setDate(END_DEFAULT_DATE_TIME.getDate() + 7);
-  END_DEFAULT_DATE_TIME.setHours(0);
-  END_DEFAULT_DATE_TIME.setMinutes(0);
-  const END_AT_MIN_DATE_TIME = new Date();
-  END_AT_MIN_DATE_TIME.setDate(END_AT_MIN_DATE_TIME.getDate() + 1);
-  END_AT_MIN_DATE_TIME.setHours(0);
-  END_AT_MIN_DATE_TIME.setMinutes(0);
-  const END_AT_MAX_DATE_TIME = new Date();
-  END_AT_MAX_DATE_TIME.setMonth(END_AT_MAX_DATE_TIME.getMonth() + 1);
-  END_AT_MAX_DATE_TIME.setHours(0);
-  END_AT_MAX_DATE_TIME.setMinutes(0);
+  const END_DEFAULT_DATE_TIME = START_DEFAULT_DATE_TIME.add(7, 'day');
+  const END_AT_MIN_DATE_TIME = START_DEFAULT_DATE_TIME.add(1, 'day');
+  const END_AT_MAX_DATE_TIME = START_DEFAULT_DATE_TIME.add(30, 'day');
+
+  const DATE_FORMAT = 'YYYY-MM-DDThh:mm';
+
+  const FILE_LIMIT_SIZE = 5 * 1024 * 1024;
 
   const showPicker = (e: Event) => {
     if (e.target instanceof HTMLInputElement) {
@@ -49,20 +38,21 @@
     }
   };
 
-  const FILE_LIMIT_SIZE = 5 * 1024 * 1024;
-
   export let onConfirm: (values: Required<TProductForm>) => unknown;
 
   export let product: TProduct | undefined = undefined;
   export let pageType: 'new' | 'edit';
+
   const { form, data } = createForm({
     initialValues: {
       ...product,
       name: product?.name || '',
       kinds: product?.kinds || CROP_KINDS.vegetables,
       description: product?.description || '',
-      startAt: product?.startAt || START_DEFAULT_DATE_TIME.toISOString().slice(0, 16),
-      endAt: product?.endAt || END_DEFAULT_DATE_TIME.toISOString().slice(0, 16),
+      startAt: product?.startAt
+        ? dayjs(product.startAt).format(DATE_FORMAT)
+        : START_DEFAULT_DATE_TIME.format(DATE_FORMAT),
+      endAt: product?.endAt ? dayjs(product.endAt).format(DATE_FORMAT) : END_DEFAULT_DATE_TIME.format(DATE_FORMAT),
       unit: product?.unit || CROP_UNITS.gram,
       unitQuantity: product?.unitQuantity || 1,
       unitPrice: product?.unitPrice || 0,
@@ -166,8 +156,8 @@
           bind:value={$data.startAt}
           type="datetime-local"
           required
-          input$min={START_AT_MIN_DATE_TIME.toISOString().slice(0, 16)}
-          input$max={START_AT_MAX_DATE_TIME.toISOString().slice(0, 16)}
+          input$min={START_AT_MIN_DATE_TIME.format(DATE_FORMAT)}
+          input$max={START_AT_MAX_DATE_TIME.format(DATE_FORMAT)}
           on:click={showPicker}
         />
         <span class="label ml-3 mr-3 text-text-lightGray">～</span>
@@ -178,8 +168,8 @@
           bind:value={$data.endAt}
           type="datetime-local"
           required
-          input$min={END_AT_MIN_DATE_TIME.toISOString().slice(0, 16)}
-          input$max={END_AT_MAX_DATE_TIME.toISOString().slice(0, 16)}
+          input$min={END_AT_MIN_DATE_TIME.format(DATE_FORMAT)}
+          input$max={END_AT_MAX_DATE_TIME.format(DATE_FORMAT)}
           on:click={showPicker}
         />
       </div>

--- a/web/app/src/pages/product/new.svelte
+++ b/web/app/src/pages/product/new.svelte
@@ -38,5 +38,5 @@
 </script>
 
 <div>
-  <ProductForm {onConfirm} />
+  <ProductForm pageType="new" {onConfirm} />
 </div>


### PR DESCRIPTION
# 概要

出品内容を編集する機能を追加しました。

# 変更点
  
* (web)

  * 出品詳細画面に編集ボタンを追加
  * 出品内容編集画面を新規作成
  * 出品フォーム生成画面(ProductFrom.svelte)を編集でも活用できるよう改修
    * 出品フォーム内の開始日・終了日が要求仕様に準じていなかったため、修正
      * 予約開始日が画面を開いた日時の、前日15:00になっていた → 画面を開いた日時に修正
      * 月次第では終了日が開始日からの期間を31日にできた → 月に関わらず終了日のMAXが30日になるよう修正

* (back)

  * 出品内容編集向けの新規APIを追加　PATCH /products/:productId
  * PATCHメソッドをCORSのAcess-Controll-Allow-Methodsに追加
  → お願い事項あり To:  @Mirenk 

# 動作確認内容

### 画面操作での確認

  * 出品詳細画面にて、生産者の場合のみ編集ボタンが表示されること
    * 出品が終了(数量0) している時に編集ボタンが表示されないこと
  * 出品詳細画面の編集ボタンを押下して 出品内容編集画面が表示されること
    * 表示されるフォームには出品登録時の情報が初期値に設定されていること
  * 出品内容編集画面のキャンセルボタンを押下すると、変更が反映されずに出品詳細画面に戻ること
  * 出品内容編集画面の編集ボタンを押下後、変更した項目が反映されること

### API直接呼び出しでの確認

  * name パラメータのみが記述されたjsonをリクエストし、エラーが発生せずに商品名のみが変更されること
