### PR TITLE
予約内容編集機能を追加

### DIFF
--- a/server/app/src/reservation/dto/update-reservation.dto.ts
+++ b/server/app/src/reservation/dto/update-reservation.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateReservationDto } from './create-reservation.dto';
+
+export class UpdateReservationDto extends PartialType(CreateReservationDto) {}

--- a/server/app/src/reservation/reservation.controller.ts
+++ b/server/app/src/reservation/reservation.controller.ts
@@ -1,9 +1,10 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Patch, Put, UseGuards } from '@nestjs/common';
 import { Account } from 'src/account/entities/account.entity';
 import { GetAccount } from 'src/account/get-account.decorator';
 import { JwtAuthGuard } from 'src/account/jwt-auth.guard';
 import { CreateReservationDto } from './dto/create-reservation.dto';
 import { UpdateReservationForPackedDto } from './dto/update-reservation-for-packed.dto';
+import { UpdateReservationDto } from './dto/update-reservation.dto';
 import { TReservation } from './entities/reservation.entity';
 import { ReservationService } from './reservation.service';
 
@@ -29,6 +30,15 @@ export class ReservationController {
     @GetAccount() account: Account,
   ): Promise<TReservation> {
     return this.reservationService.createReservation(createReservationDto, account);
+  }
+
+  @Patch('/products/:reservationId')
+  async updateReservation(
+    @Body() updateReservationDto: UpdateReservationDto,
+    @GetAccount() account: Account,
+    @Param('reservationId') reservationId: string,
+  ): Promise<TReservation> {
+    return this.reservationService.updateReservation(updateReservationDto, account, reservationId);
   }
 
   @Put('/products/:reservationId/packed')

--- a/web/app/src/models/Reservation.ts
+++ b/web/app/src/models/Reservation.ts
@@ -49,6 +49,14 @@ export class ReservationRepository {
     });
   }
 
+  async update(id: string, body: TReservationForm): Promise<TReservation> {
+    return await baseAPI<TReservation>({
+      endpoint: `${this.baseEndpoint}/products/${id}`,
+      method: 'PATCH',
+      body,
+    });
+  }
+
   async packed(id: string, body: TReservationPackedForm): Promise<TReservation> {
     return await baseAPI<TReservation>({
       endpoint: `${this.baseEndpoint}/products/${id}/packed`,

--- a/web/app/src/pages/reservation/[id]/edit.svelte
+++ b/web/app/src/pages/reservation/[id]/edit.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { goto, params } from '@roxi/routify';
+  import CircularProgress from '@smui/circular-progress';
+  import { ReservationRepository, type TReservationForm, type TReservation } from '../../../models/Reservation';
+  import { addToast } from '../../../stores/Toast';
+  import { handleError } from '../../../utils/error-handle-helper';
+  import ReservationForm from '../_components/ReservationForm.svelte';
+
+  $: reservationRepository = new ReservationRepository();
+
+  async function fetchReservation(): Promise<TReservation> {
+    try {
+      return await reservationRepository.findOne($params.id);
+    } catch (err) {
+      handleError(err, '予約の取得');
+    }
+  }
+
+  async function onConfirm(values: Required<TReservationForm>) {
+    const operation = '予約の編集';
+    await reservationRepository
+      .update($params.id, { ...values })
+      .then(() => {
+        addToast({
+          message: `${operation}に成功しました。`,
+        });
+        $goto('./');
+      })
+      .catch((err) => {
+        handleError(err, operation);
+      });
+  }
+</script>
+
+{#await fetchReservation()}
+  <div class="flex justify-center">
+    <CircularProgress class="h-40 w-8" indeterminate />
+  </div>
+{:then reservation}
+  <div>
+    <ReservationForm pageType="edit" {onConfirm} {reservation} />
+  </div>
+{/await}

--- a/web/app/src/pages/reservation/[id]/index.svelte
+++ b/web/app/src/pages/reservation/[id]/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { params } from '@roxi/routify';
+  import { params, goto } from '@roxi/routify';
   import Button from '@smui/button';
   import CircularProgress from '@smui/circular-progress';
   import Paper from '@smui/paper';
@@ -187,11 +187,14 @@
       {/if}
       {#if canEdit(reservationData)}
         <div>
-          <!-- TODO:ボタン配置しただけなので要ページ遷移処理。
-          <Button class="  mr-2 w-[150px] rounded-full px-4 py-2" color="secondary" variant="raised">
+          <Button
+            class="w-[150px] rounded-full px-4 py-2"
+            color="secondary"
+            variant="raised"
+            on:click={$goto('../../reservation/:id/edit', { productId: reservationData.productId })}
+          >
             <p class="text-lg font-bold">編集</p>
-          </Button> -->
-
+          </Button>
           <Button
             class="w-[150px] rounded-full px-4 py-2"
             color="secondary"

--- a/web/app/src/pages/reservation/_components/ReservationForm.svelte
+++ b/web/app/src/pages/reservation/_components/ReservationForm.svelte
@@ -11,17 +11,26 @@
   import { ProductRepository, type TProduct } from '../../../models/Product';
   import { AccountService } from '../../../services/AccountService';
   import { handleError } from '../../../utils/error-handle-helper';
-  import type { TReservationForm } from '../../../models/Reservation';
+  import type { TReservationForm, TReservation } from '../../../models/Reservation';
+
+  const QUANTITY_MAX = 100;
+  const QUANTITY_MIN = 1;
+
+  const DESIRE_DEFAULT_DATE_TIME = dayjs().minute(0);
+
+  const DATE_FORMAT_DESCRIPTION = 'MM/DD HH:mm';
+  const DATE_FORMAT_TEXTFIELD = 'YYYY-MM-DDTHH:mm';
 
   export let onConfirm: (values: Required<TReservationForm>) => unknown;
+
+  export let reservation: TReservation | undefined = undefined;
+  export let pageType: 'new' | 'edit';
 
   let shops: Record<string, string>[] | undefined = [];
   let shopIds: Record<string, string> | undefined = undefined;
   let selectedProduct: TProduct;
   let totalPrice = 0;
-  let reservationRangeMax: number;
-  const RESERVATION_MAX = 100;
-  const RESERVATION_MIN = 1;
+  let quantityRangeMax: number;
 
   onMount(async () => {
     try {
@@ -30,16 +39,12 @@
         new AccountService().getShops(),
       ]);
       shopIds = Object.fromEntries(shops.map(({ id, name }) => [id, name]));
-      reservationRangeMax = selectedProduct.remaining > RESERVATION_MAX ? RESERVATION_MAX : selectedProduct.remaining;
+      quantityRangeMax = selectedProduct.remaining > QUANTITY_MAX ? QUANTITY_MAX : selectedProduct.remaining;
       totalPrice = selectedProduct.unitPrice;
     } catch (err) {
       handleError(err);
     }
   });
-
-  const DESIRE_DEFAULT_DATE_TIME = new Date();
-  DESIRE_DEFAULT_DATE_TIME.setHours(0);
-  DESIRE_DEFAULT_DATE_TIME.setMinutes(0);
 
   const showPicker = (e: Event) => {
     if (e.target instanceof HTMLInputElement) {
@@ -47,34 +52,28 @@
     }
   };
 
-  // フォームの項目
-  let quantity = 1;
-  let desiredAt = DESIRE_DEFAULT_DATE_TIME.toISOString().slice(0, 16);
-  let receiveLocationId = shopIds ? Object.keys(shopIds)[0] : '';
-
-  const initialValues = {
-    quantity: 1,
-    desiredAt: DESIRE_DEFAULT_DATE_TIME.toISOString().slice(0, 16),
-    receiveLocationId: shopIds ? Object.keys(shopIds)[0] : '',
-    // totalPrice: totalPrice
-  };
-
   // TODO: バリデーションの実装
-  const { form } = createForm({
-    initialValues,
+  const { form, data } = createForm({
+    initialValues: {
+      quantity: reservation?.quantity || 1,
+      desiredAt: reservation?.desiredAt
+        ? dayjs(reservation.desiredAt).format(DATE_FORMAT_TEXTFIELD)
+        : DESIRE_DEFAULT_DATE_TIME.format(DATE_FORMAT_TEXTFIELD),
+      receiveLocationId: reservation?.receiveLocationId || '',
+    },
     onSubmit: async (values) => {
       await onConfirm({
         ...values,
         productId: selectedProduct.id,
-        quantity: quantity,
-        desiredAt: desiredAt,
-        receiveLocationId: receiveLocationId,
+        quantity: $data.quantity,
+        desiredAt: $data.desiredAt,
+        receiveLocationId: $data.receiveLocationId,
       });
     },
   });
 
   function calcTotalPrice() {
-    totalPrice = quantity * selectedProduct.unitPrice;
+    totalPrice = $data.quantity * selectedProduct.unitPrice;
   }
 </script>
 
@@ -113,9 +112,9 @@
         <div class="mt-2 text-center text-base text-[#5A5A5A]">残りあと{selectedProduct.remaining}点</div>
         <div class="mt-2 text-center text-base text-[#5A5A5A]">
           予約期間：
-          {dayjs(selectedProduct.startAt).format('MM/DD HH:mm')}
+          {dayjs(selectedProduct.startAt).format(DATE_FORMAT_DESCRIPTION)}
           -
-          {dayjs(selectedProduct.endAt).format('MM/DD HH:mm')}
+          {dayjs(selectedProduct.endAt).format(DATE_FORMAT_DESCRIPTION)}
         </div>
       </Paper>
     </div>
@@ -125,12 +124,12 @@
         <Textfield
           class="m-3 w-[200px]"
           label="予約数量"
-          bind:value={quantity}
+          bind:value={$data.quantity}
           required
           type={'number'}
           suffix="点"
-          input$min={RESERVATION_MIN}
-          input$max={reservationRangeMax}
+          input$min={QUANTITY_MIN}
+          input$max={quantityRangeMax}
           on:change={calcTotalPrice}
         />
       </div>
@@ -140,11 +139,11 @@
           class="m-3 w-[200px]"
           variant="standard"
           label="受け取り希望日時"
-          bind:value={desiredAt}
+          bind:value={$data.desiredAt}
           type="datetime-local"
           required
-          input$min={new Date(selectedProduct.startAt).toISOString().slice(0, 16)}
-          input$max={new Date(selectedProduct.endAt).toISOString().slice(0, 16)}
+          input$min={dayjs(selectedProduct.startAt).format(DATE_FORMAT_TEXTFIELD)}
+          input$max={dayjs(selectedProduct.endAt).format(DATE_FORMAT_TEXTFIELD)}
           on:click={showPicker}
         />
       </div>
@@ -156,7 +155,7 @@
               class="m-3 w-[200px]"
               label="受け取り場所"
               variant="standard"
-              bind:value={receiveLocationId}
+              bind:value={$data.receiveLocationId}
               required
             >
               {#each Object.keys(shopIds) as shopId}
@@ -164,12 +163,12 @@
               {/each}
             </Select>
           </div>
-          {#if receiveLocationId}
+          {#if $data.receiveLocationId}
             <div class="flex justify-center">
               <Paper class="w-[200px] p-1" color="secondary" variant="outlined">
                 <div class="text-base text-[#5A5A5A]">
-                  <div>〒{shops.find((shop) => shop.id === receiveLocationId).zipCode}</div>
-                  <div>{shops.find((shop) => shop.id === receiveLocationId).address}</div>
+                  <div>〒{shops.find((shop) => shop.id === $data.receiveLocationId).zipCode}</div>
+                  <div>{shops.find((shop) => shop.id === $data.receiveLocationId).address}</div>
                 </div>
               </Paper>
             </div>
@@ -192,7 +191,7 @@
           <p class="black">キャンセル</p>
         </Button>
         <Button variant="raised" class="mt-10 w-[150px] rounded-full px-4 py-2" color="secondary" type="submit">
-          <p class="black">予約確定</p>
+          <p class="black">{pageType === 'new' ? '予約確定' : '編集'}</p>
         </Button>
       </div>
     </form>

--- a/web/app/src/pages/reservation/new.svelte
+++ b/web/app/src/pages/reservation/new.svelte
@@ -23,5 +23,5 @@
 </script>
 
 <div>
-  <ReservationForm {onConfirm} />
+  <ReservationForm pageType="new" {onConfirm} />
 </div>


### PR DESCRIPTION
# 概要

予約内容を編集する機能を追加しました。

# 変更点
  
* (web)

  * 予約詳細画面に編集ボタンを追加
  * 予約内容編集画面を新規作成
  * 予約フォームのコンポーネント(ReservationFrom.svelte)を編集でも活用できるよう改修
    * 予約フォーム内の受取り希望日が要求仕様に準じていなかったため、修正
      * 予約開始日が画面を開いた日時の、前日15:00になっていた → 画面を開いた日時に修正

* (back)

  * 出品内容編集向けの新規APIを追加　PATCH /reservations/products/:reservationId

# 動作確認内容

### 画面操作での確認

  * 予約詳細画面にて、予約者の場合のみ編集ボタンが表示されること
  * 予約詳細画面の編集ボタンを押下して 予約内容編集画面が表示されること
    * 表示されるフォームには予約登録時の情報が初期値に設定されていること
  * 予約内容編集画面のキャンセルボタンを押下すると、変更が反映されずに予約詳細画面に戻ること
  * 予約内容編集画面の編集ボタンを押下後、変更した項目が反映された予約詳細画面に戻ること
    * 予約数量を変更し、作物の数量が期待通り変更されていること
    作物の数量を10で出品 -> 予約数量2で予約 (作物の数量が8になる) -> 予約数量3で編集 (作物の数量が7になる)

### API直接呼び出しでの確認

  * quantity パラメータのみが記述されたjsonをリクエストし、エラーが発生せずに予約数量のみが変更されること
    * 予約対象の作物の数量が変更後の値になっていること
