### PR TITLE
物流業者向け物流設定で便の削除ができる

### DIFF
--- a/server/app/src/logistics/logistics.controller.ts
+++ b/server/app/src/logistics/logistics.controller.ts
@@ -78,6 +78,11 @@ export class LogisticsController {
     return this.logisticService.createTrip(account, dto);
   }
 
+  @Delete('/setting/logistics/:logisticsId/trip/:tripId')
+  async deleteTrip(@Param('logisticsId') logisticsId: string, @Param('tripId') tripId: string) {
+    return this.logisticService.deleteTrip(logisticsId, tripId);
+  }
+
   @Put('/setting/logistics/:logisticsId/deliveryType')
   async updateDeliveryType(@Param('logisticsId') logisticsId: string, @Body() dto: UpdateDeliveryTypeDto) {
     return this.logisticService.updateDeliveryType(logisticsId, dto);

--- a/server/app/src/logistics/logistics.controller.ts
+++ b/server/app/src/logistics/logistics.controller.ts
@@ -82,9 +82,14 @@ export class LogisticsController {
     return this.logisticService.createTrip(account, dto);
   }
 
-  @Delete('/setting/logistics/:logisticsId/trip/:tripId')
-  async deleteTrip(@Param('logisticsId') logisticsId: string, @Param('tripId') tripId: string) {
-    return this.logisticService.deleteTrip(logisticsId, tripId);
+  @Delete('/setting/logistics/:logisticsId/route/:routeId/trip/:tripId')
+  async deleteTrip(
+    @Param('logisticsId') logisticsId: string,
+    @Param('routeId') routeId: string,
+    @Param('tripId') tripId: string,
+    @GetAccount() account: Account,
+  ) {
+    return this.logisticService.deleteTrip(account, logisticsId, routeId, tripId);
   }
 
   @Put('/setting/logistics/:logisticsId/deliveryType')

--- a/server/app/src/logistics/logistics.service.ts
+++ b/server/app/src/logistics/logistics.service.ts
@@ -141,6 +141,27 @@ export class LogisticsService {
     // TODO 便追加の処理
   }
 
+  async deleteTrip(logisticsId: string, tripId: string): Promise<LogisticsSettingForLogistics> {
+    const trip = await this.tripRepository.findOne({ where: { id: tripId } });
+    if (!trip) {
+      throw new BadRequestException();
+    }
+    await this.tripRepository.remove(trip);
+
+    const setting = await this.logisticsSettingRepository
+      .findOne({
+        where: { logisticsId },
+        relations: ['routes', 'routes.trips', 'routes.trips.timetables'],
+      })
+      .then((setting) => setting);
+
+    if (!setting) {
+      throw new BadRequestException();
+    }
+
+    return setting;
+  }
+
   async updateDeliveryType(logisticsId: string, dto: UpdateDeliveryTypeDto): Promise<LogisticsSettingForLogistics> {
     const setting = await this.logisticsSettingRepository
       .findOne({

--- a/server/app/src/logistics/logistics.service.ts
+++ b/server/app/src/logistics/logistics.service.ts
@@ -145,11 +145,27 @@ export class LogisticsService {
     // TODO 便追加の処理
   }
 
-  async deleteTrip(logisticsId: string, tripId: string): Promise<LogisticsSettingForLogistics> {
-    const trip = await this.tripRepository.findOne({ where: { id: tripId } });
-    if (!trip) {
+  async deleteTrip(
+    account: Account,
+    logisticsId: string,
+    routeId: string,
+    tripId: string,
+  ): Promise<LogisticsSettingForLogistics> {
+    if (account.id !== logisticsId) {
       throw new BadRequestException();
     }
+
+    const existsSetting = await this.logisticsSettingRepository
+      .findOne({
+        where: { logisticsId, routes: { id: routeId, trips: { id: tripId } } },
+        relations: ['routes', 'routes.trips'],
+      })
+      .then((setting) => setting);
+    if (!existsSetting) {
+      throw new BadRequestException();
+    }
+
+    const trip = await this.tripRepository.findOne({ where: { id: tripId } });
     await this.tripRepository.remove(trip);
 
     const setting = await this.logisticsSettingRepository

--- a/web/app/src/models/Logistics.ts
+++ b/web/app/src/models/Logistics.ts
@@ -99,4 +99,11 @@ export class LogisticsRepository {
       endpoint: `${this.baseEndpoint}/tripsuggestions?logisticsId=${logisticsId}&pickup-stop=${pickupStop}&delivery-stop=${deliveryStop}&count=${count}`,
     });
   }
+
+  async deleteTrip(logisticsSettingId: string, tripId: string): Promise<TLogisticsSetting> {
+    return await baseAPI<TLogisticsSetting>({
+      endpoint: `${this.baseEndpoint}/setting/logistics/${logisticsSettingId}/trip/${tripId}`,
+      method: 'DELETE',
+    });
+  }
 }

--- a/web/app/src/models/Logistics.ts
+++ b/web/app/src/models/Logistics.ts
@@ -100,9 +100,9 @@ export class LogisticsRepository {
     });
   }
 
-  async deleteTrip(logisticsSettingId: string, tripId: string): Promise<TLogisticsSetting> {
+  async deleteTrip(logisticsSettingId: string, routeId: string, tripId: string): Promise<TLogisticsSetting> {
     return await baseAPI<TLogisticsSetting>({
-      endpoint: `${this.baseEndpoint}/setting/logistics/${logisticsSettingId}/trip/${tripId}`,
+      endpoint: `${this.baseEndpoint}/setting/logistics/${logisticsSettingId}/route/${routeId}/trip/${tripId}`,
       method: 'DELETE',
     });
   }

--- a/web/app/src/pages/logistics/setting/_components/LogisticsRouteAccordion.svelte
+++ b/web/app/src/pages/logistics/setting/_components/LogisticsRouteAccordion.svelte
@@ -40,7 +40,7 @@
       </Header>
       <Content>
         {#each route.trips as trip}
-          <LogisticsTripAccordion bind:logisticsSetting {trip} />
+          <LogisticsTripAccordion bind:logisticsSetting {route} {trip} />
         {/each}
 
         <div class="flex justify-center">

--- a/web/app/src/pages/logistics/setting/_components/LogisticsRouteAccordion.svelte
+++ b/web/app/src/pages/logistics/setting/_components/LogisticsRouteAccordion.svelte
@@ -40,7 +40,7 @@
       </Header>
       <Content>
         {#each route.trips as trip}
-          <LogisticsTripAccordion {trip} />
+          <LogisticsTripAccordion bind:logisticsSetting {trip} />
         {/each}
 
         <div class="flex justify-center">

--- a/web/app/src/pages/logistics/setting/_components/LogisticsTripAccordion.svelte
+++ b/web/app/src/pages/logistics/setting/_components/LogisticsTripAccordion.svelte
@@ -4,13 +4,22 @@
   import Accordion, { Panel, Header, Content } from '@smui-extra/accordion';
   import dayjs from 'dayjs';
   import { SHOCK_LEVEL_LABEL, SHOCK_LEVEL } from '../../../../constants/product';
-  import type { TTripSetting } from '../../../../models/Logistics';
+  import TripDeleteDialog from './TripDeleteDialog.svelte';
+  import type { TTripSetting, TLogisticsSetting } from '../../../../models/Logistics';
 
+  export let logisticsSetting: TLogisticsSetting = null;
   export let trip: TTripSetting;
   $: panelOpen = false;
 
+  let isTripDeleteDialogOpen = false;
+
   function formatPickupTime(timeString) {
     return timeString ? dayjs(timeString).format('HH:mm') : '';
+  }
+
+  function onClickTripDeleteButton(event: Event) {
+    event.stopPropagation();
+    isTripDeleteDialogOpen = true;
   }
 </script>
 
@@ -31,7 +40,7 @@
         {trip.name}
         <span slot="icon">
           <IconButton class="material-icons" disabled>edit</IconButton>
-          <IconButton class="material-icons" disabled>delete</IconButton>
+          <IconButton class="material-icons" on:click={onClickTripDeleteButton}>delete</IconButton>
         </span>
       </Header>
       <Content>
@@ -73,4 +82,5 @@
       </Content>
     </Panel>
   </Accordion>
+  <TripDeleteDialog bind:open={isTripDeleteDialogOpen} bind:logisticsSetting {trip} />
 </div>

--- a/web/app/src/pages/logistics/setting/_components/LogisticsTripAccordion.svelte
+++ b/web/app/src/pages/logistics/setting/_components/LogisticsTripAccordion.svelte
@@ -5,9 +5,10 @@
   import dayjs from 'dayjs';
   import { SHOCK_LEVEL_LABEL, SHOCK_LEVEL } from '../../../../constants/product';
   import TripDeleteDialog from './TripDeleteDialog.svelte';
-  import type { TTripSetting, TLogisticsSetting } from '../../../../models/Logistics';
+  import type { TTripSetting, TRouteSetting, TLogisticsSetting } from '../../../../models/Logistics';
 
   export let logisticsSetting: TLogisticsSetting = null;
+  export let route: TRouteSetting;
   export let trip: TTripSetting;
   $: panelOpen = false;
 
@@ -82,5 +83,5 @@
       </Content>
     </Panel>
   </Accordion>
-  <TripDeleteDialog bind:open={isTripDeleteDialogOpen} bind:logisticsSetting {trip} />
+  <TripDeleteDialog bind:open={isTripDeleteDialogOpen} bind:logisticsSetting {route} {trip} />
 </div>

--- a/web/app/src/pages/logistics/setting/_components/TripDeleteDialog.svelte
+++ b/web/app/src/pages/logistics/setting/_components/TripDeleteDialog.svelte
@@ -1,11 +1,17 @@
 <script lang="ts">
   import ConfirmDialog from '../../../../components/customized/ConfirmDialog.svelte';
-  import { LogisticsRepository, type TTripSetting, type TLogisticsSetting } from '../../../../models/Logistics';
+  import {
+    LogisticsRepository,
+    type TTripSetting,
+    type TRouteSetting,
+    type TLogisticsSetting,
+  } from '../../../../models/Logistics';
   import { addToast } from '../../../../stores/Toast';
   import { handleError } from '../../../../utils/error-handle-helper';
 
   export let open: boolean;
   export let logisticsSetting: TLogisticsSetting = null;
+  export let route: TRouteSetting;
   export let trip: TTripSetting;
 
   let logisticsRepository: LogisticsRepository = new LogisticsRepository();
@@ -23,7 +29,7 @@
 
   async function deleteTrip() {
     try {
-      logisticsSetting = await logisticsRepository.deleteTrip(logisticsSetting.logisticsId, trip.id);
+      logisticsSetting = await logisticsRepository.deleteTrip(logisticsSetting.logisticsId, route.id, trip.id);
       addToast({
         message: '便を削除しました。',
       });

--- a/web/app/src/pages/logistics/setting/_components/TripDeleteDialog.svelte
+++ b/web/app/src/pages/logistics/setting/_components/TripDeleteDialog.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import ConfirmDialog from '../../../../components/customized/ConfirmDialog.svelte';
+  import { LogisticsRepository, type TTripSetting, type TLogisticsSetting } from '../../../../models/Logistics';
+  import { addToast } from '../../../../stores/Toast';
+  import { handleError } from '../../../../utils/error-handle-helper';
+
+  export let open: boolean;
+  export let logisticsSetting: TLogisticsSetting = null;
+  export let trip: TTripSetting;
+
+  let logisticsRepository: LogisticsRepository = new LogisticsRepository();
+
+  async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
+    switch (e.detail.action) {
+      case 'delete':
+        await deleteTrip();
+        break;
+      default:
+        // NOP
+        break;
+    }
+  }
+
+  async function deleteTrip() {
+    try {
+      logisticsSetting = await logisticsRepository.deleteTrip(logisticsSetting.logisticsId, trip.id);
+      addToast({
+        message: '便を削除しました。',
+      });
+    } catch (err) {
+      handleError(err);
+    }
+  }
+</script>
+
+<ConfirmDialog
+  bind:open
+  closedAction={onDialogClosedHandle}
+  title={`「${trip.name}」を削除しますか？`}
+  negativeButtonName="キャンセル"
+  negativeButtonAction="close"
+  positiveButtonName="削除"
+  positiveButtonAction="delete"
+/>


### PR DESCRIPTION
# 概要

物流業者向け物流設定で便の削除ができるように対応した。

# 変更点
  
* 物流業者向け物流設定で便の削除ができるように対応した

# 動作確認内容

* 物流業者向け物流設定において、便のアコーディオン上にある削除アイコンを押して、便削除ダイアログが開くことを確認
* 便削除ダイアログでキャンセルボタンを押してダイアログが閉じられることを確認
* 便削除ダイアログで削除ボタンを押して、削除メッセージのトースト表示とともに、該当の便が削除されることを確認
