### PR TITLE
物流業者向け物流設定画面での便編集機能の実装 

### DIFF
--- a/server/app/src/logistics/logistics.controller.ts
+++ b/server/app/src/logistics/logistics.controller.ts
@@ -86,10 +86,20 @@ export class LogisticsController {
     return this.logisticService.createTrip(logisticsId, routeId, dto);
   }
 
+  @Put('/setting/logistics/:logisticsId/trip/:tripId/edit')
+  async editTrip(
+    @Param('logisticsId') logisticsId: string,
+    @Param('tripId') tripId: string,
+    @Body() dto: CreateTripDto,
+  ) {
+    return this.logisticService.updateTrip(logisticsId, tripId, dto);
+  }
+
   @Put('/setting/logistics/:logisticsId/deliveryType')
   async updateDeliveryType(@Param('logisticsId') logisticsId: string, @Body() dto: UpdateDeliveryTypeDto) {
     return this.logisticService.updateDeliveryType(logisticsId, dto);
   }
+
   @Post('/schedule')
   @HttpCode(HttpStatus.CREATED)
   async createShippingSchedule(@Body() dto: CreateShippingScheduleDto) {

--- a/server/app/src/logistics/logistics.controller.ts
+++ b/server/app/src/logistics/logistics.controller.ts
@@ -85,17 +85,20 @@ export class LogisticsController {
     @Param('logisticsId') logisticsId: string,
     @Param('routeId') routeId: string,
     @Body() dto: CreateTripDto,
+    @GetAccount() account: Account,
   ) {
-    return this.logisticService.createTrip(logisticsId, routeId, dto);
+    return this.logisticService.createTrip(account, logisticsId, routeId, dto);
   }
 
-  @Put('/setting/logistics/:logisticsId/trip/:tripId/edit')
+  @Put('/setting/logistics/:logisticsId/route/:routeId/trip/:tripId')
   async editTrip(
     @Param('logisticsId') logisticsId: string,
+    @Param('routeId') routeId: string,
     @Param('tripId') tripId: string,
     @Body() dto: UpdateTripDto,
+    @GetAccount() account: Account,
   ) {
-    return this.logisticService.updateTrip(logisticsId, tripId, dto);
+    return this.logisticService.updateTrip(account, logisticsId, routeId, tripId, dto);
   }
 
   @Delete('/setting/logistics/:logisticsId/route/:routeId/trip/:tripId')

--- a/web/app/src/models/Logistics.ts
+++ b/web/app/src/models/Logistics.ts
@@ -162,9 +162,14 @@ export class LogisticsRepository {
     });
   }
 
-  async updateTrip(logisticsId: string, tripId: string, body: TUpdateTripForm): Promise<TLogisticsSetting> {
+  async updateTrip(
+    logisticsId: string,
+    routeId: string,
+    tripId: string,
+    body: TUpdateTripForm,
+  ): Promise<TLogisticsSetting> {
     return await baseAPI({
-      endpoint: `${this.baseEndpoint}/setting/logistics/${logisticsId}/trip/${tripId}/edit`,
+      endpoint: `${this.baseEndpoint}/setting/logistics/${logisticsId}/route/${routeId}/trip/${tripId}`,
       method: 'PUT',
       body,
     });

--- a/web/app/src/models/Logistics.ts
+++ b/web/app/src/models/Logistics.ts
@@ -109,4 +109,12 @@ export class LogisticsRepository {
       body,
     });
   }
+
+  async updateTrip(logisticsId: string, tripId: string, body: TTripForm): Promise<TLogisticsSetting> {
+    return await baseAPI({
+      endpoint: `${this.baseEndpoint}/setting/logistics/${logisticsId}/trip/${tripId}/edit`,
+      method: 'PUT',
+      body,
+    });
+  }
 }

--- a/web/app/src/pages/logistics/setting/_components/LogisticsRouteAccordion.svelte
+++ b/web/app/src/pages/logistics/setting/_components/LogisticsRouteAccordion.svelte
@@ -42,7 +42,7 @@
       </Header>
       <Content>
         {#each route.trips as trip}
-          <LogisticsTripAccordion {trip} />
+          <LogisticsTripAccordion {trip} routeId={route.id} {logisticsSetting} />
         {/each}
 
         <div class="flex justify-center">

--- a/web/app/src/pages/logistics/setting/_components/LogisticsTripAccordion.svelte
+++ b/web/app/src/pages/logistics/setting/_components/LogisticsTripAccordion.svelte
@@ -4,10 +4,14 @@
   import Accordion, { Panel, Header, Content } from '@smui-extra/accordion';
   import dayjs from 'dayjs';
   import { SHOCK_LEVEL_LABEL, SHOCK_LEVEL } from '../../../../constants/product';
-  import type { TTripSetting } from '../../../../models/Logistics';
+  import TripEditDialog from './TripEditDialog.svelte';
+  import type { TLogisticsSetting, TTripSetting } from '../../../../models/Logistics';
 
   export let trip: TTripSetting;
   $: panelOpen = false;
+  let isTripEditDialogOpen = false;
+  export let routeId;
+  export let logisticsSetting: TLogisticsSetting = null;
 
   function formatPickupTime(timeString) {
     return timeString ? dayjs(timeString).format('HH:mm') : '';
@@ -30,7 +34,13 @@
         {/if}
         {trip.name}
         <span slot="icon">
-          <IconButton class="material-icons" disabled>edit</IconButton>
+          <IconButton
+            class="material-icons"
+            on:click={(e) => {
+              isTripEditDialogOpen = true;
+              e.stopPropagation();
+            }}>edit</IconButton
+          >
           <IconButton class="material-icons" disabled>delete</IconButton>
         </span>
       </Header>
@@ -73,4 +83,5 @@
       </Content>
     </Panel>
   </Accordion>
+  <TripEditDialog bind:open={isTripEditDialogOpen} {routeId} bind:logisticsSetting bind:trip />
 </div>

--- a/web/app/src/pages/logistics/setting/_components/LogisticsTripAccordion.svelte
+++ b/web/app/src/pages/logistics/setting/_components/LogisticsTripAccordion.svelte
@@ -91,6 +91,6 @@
       </Content>
     </Panel>
   </Accordion>
-  <TripEditDialog bind:open={isTripEditDialogOpen} {route} bind:logisticsSetting bind:trip />
+  <TripEditDialog bind:open={isTripEditDialogOpen} bind:logisticsSetting {route} {trip} />
   <TripDeleteDialog bind:open={isTripDeleteDialogOpen} bind:logisticsSetting {route} {trip} />
 </div>

--- a/web/app/src/pages/logistics/setting/_components/LogisticsTripAccordion.svelte
+++ b/web/app/src/pages/logistics/setting/_components/LogisticsTripAccordion.svelte
@@ -20,6 +20,11 @@
     return timeString ? dayjs(timeString).format('HH:mm') : '';
   }
 
+  function onClickTripEditButton(event: Event) {
+    event.stopPropagation();
+    isTripEditDialogOpen = true;
+  }
+
   function onClickTripDeleteButton(event: Event) {
     event.stopPropagation();
     isTripDeleteDialogOpen = true;
@@ -42,13 +47,7 @@
         {/if}
         {trip.name}
         <span slot="icon">
-          <IconButton
-            class="material-icons"
-            on:click={(e) => {
-              isTripEditDialogOpen = true;
-              e.stopPropagation();
-            }}>edit</IconButton
-          >
+          <IconButton class="material-icons" on:click={onClickTripEditButton}>edit</IconButton>
           <IconButton class="material-icons" on:click={onClickTripDeleteButton}>delete</IconButton>
         </span>
       </Header>

--- a/web/app/src/pages/logistics/setting/_components/TimetableImport.svelte
+++ b/web/app/src/pages/logistics/setting/_components/TimetableImport.svelte
@@ -50,6 +50,10 @@
     // 同一ファイルを選択してもイベントが発火するようにする
     target.value = '';
   }
+
+  function formatPickupTime(timeString) {
+    return timeString ? dayjs(timeString).format('HH:mm') : '';
+  }
 </script>
 
 <div>
@@ -80,7 +84,13 @@
         {#each timetables as timetable}
           <Row>
             <Cell class="text-center">{timetable.stop}</Cell>
-            <Cell class="text-center">{timetable.time}</Cell>
+            <!-- TODO: tripの情報はタームゾーンで入ってくるので、暫定的にlengthで分岐させてる -->
+            <!-- よい方法を探す必要あり -->
+            {#if timetable.time.length > 6}
+              <Cell class="text-center">{formatPickupTime(timetable.time)}</Cell>
+            {:else}
+              <Cell class="text-center">{timetable.time}</Cell>
+            {/if}
           </Row>
         {/each}
       </Body>

--- a/web/app/src/pages/logistics/setting/_components/TimetableImport.svelte
+++ b/web/app/src/pages/logistics/setting/_components/TimetableImport.svelte
@@ -57,7 +57,13 @@
   }
 
   function formatPickupTime(timeString) {
-    return timeString ? dayjs(timeString).format('HH:mm') : '';
+    if (dayjs(timeString, 'hh:mm', true).isValid()) {
+      return timeString;
+    } else if (dayjs(timeString).isValid()) {
+      return dayjs(timeString).format('HH:mm');
+    } else {
+      return '';
+    }
   }
 </script>
 
@@ -105,13 +111,7 @@
         {#each timetables as timetable}
           <Row>
             <Cell class="text-center">{timetable.stop}</Cell>
-            <!-- TODO: tripの情報はタームゾーンで入ってくるので、暫定的にlengthで分岐させてる -->
-            <!-- よい方法を探す必要あり -->
-            {#if timetable.time.length > 6}
-              <Cell class="text-center">{formatPickupTime(timetable.time)}</Cell>
-            {:else}
-              <Cell class="text-center">{timetable.time}</Cell>
-            {/if}
+            <Cell class="text-center">{formatPickupTime(timetable.time)}</Cell>
           </Row>
         {/each}
       </Body>

--- a/web/app/src/pages/logistics/setting/_components/TimetableImport.svelte
+++ b/web/app/src/pages/logistics/setting/_components/TimetableImport.svelte
@@ -11,6 +11,7 @@
   export let routeId;
   export let kinds;
   export let tripId;
+  $: csvUploadId = `csv_upload_${kinds === 'add' ? routeId : tripId}`;
 
   function csvFileParse(file: File) {
     parse(file, {
@@ -28,9 +29,6 @@
             type: 'error',
           });
           return;
-        }
-        if (timetables.length) {
-          timetables = [];
         }
 
         timetables = results?.data.map((el) => {
@@ -69,35 +67,19 @@
 
 <div>
   <div class="my-3 flex justify-center">
-    {#if kinds == 'add'}
-      <label
-        for={`csv_upload_${routeId}`}
-        class="cursor-pointer rounded bg-[#4499E1] px-10 py-1 font-bold text-[#ffffff] hover:bg-[#2B6CB0]"
-        >CSVインポート
-        <input
-          type="file"
-          name="file"
-          id={`csv_upload_${routeId}`}
-          accept="text/csv"
-          class="hidden"
-          on:change={csvFileOnChangeHandler}
-        />
-      </label>
-    {:else}
-      <label
-        for={`csv_upload_${tripId}`}
-        class="cursor-pointer rounded bg-[#4499E1] px-10 py-1 font-bold text-[#ffffff] hover:bg-[#2B6CB0]"
-        >CSVインポート
-        <input
-          type="file"
-          name="file"
-          id={`csv_upload_${tripId}`}
-          accept="text/csv"
-          class="hidden"
-          on:change={csvFileOnChangeHandler}
-        />
-      </label>
-    {/if}
+    <label
+      for={csvUploadId}
+      class="cursor-pointer rounded bg-[#4499E1] px-10 py-1 font-bold text-[#ffffff] hover:bg-[#2B6CB0]"
+      >CSVインポート
+      <input
+        type="file"
+        name="file"
+        id={csvUploadId}
+        accept="text/csv"
+        class="hidden"
+        on:change={csvFileOnChangeHandler}
+      />
+    </label>
   </div>
   <div class="my-3 flex justify-center">
     <DataTable stickyHeader class="max-h-[300px] w-4/5 min-w-[300px] overflow-auto">

--- a/web/app/src/pages/logistics/setting/_components/TripAddDialog.svelte
+++ b/web/app/src/pages/logistics/setting/_components/TripAddDialog.svelte
@@ -3,6 +3,7 @@
   import Dialog, { Title, Actions, Content } from '@smui/dialog';
   import Select, { Option } from '@smui/select';
   import Textfield from '@smui/textfield';
+  import dayjs from 'dayjs';
   import { SHOCK_LEVEL, SHOCK_LEVEL_LABEL } from '../../../../constants/product';
   import { LogisticsRepository, type TLogisticsSetting } from '../../../../models/Logistics';
   import { addToast } from '../../../../stores/Toast';
@@ -23,9 +24,8 @@
   async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
     switch (e.detail.action) {
       case 'createTrip':
-        newDateTimetables = timetables.map((value) => {
-          const [stop, time] = [value.stop, changeFormatDate(value.time)];
-          return { stop, time };
+        newDateTimetables = timetables.map((timetable) => {
+          return { stop: timetable.stop, time: dayjs(timetable.time, 'hh:mm', true).toISOString() };
         });
 
         await createTrip(routeId);
@@ -35,17 +35,6 @@
         break;
     }
     clearInputData();
-  }
-
-  function changeFormatDate(time: string) {
-    if (!time) {
-      return;
-    }
-    const today = new Date();
-    today.setHours(Number(time.substring(0, 2)));
-    today.setMinutes(Number(time.substring(3)));
-    today.setSeconds(0);
-    return today;
   }
 
   async function createTrip(routeId: string) {

--- a/web/app/src/pages/logistics/setting/_components/TripEditDialog.svelte
+++ b/web/app/src/pages/logistics/setting/_components/TripEditDialog.svelte
@@ -25,15 +25,10 @@
   let value = SHOCK_LEVEL_LABEL[Object.keys(SHOCK_LEVEL).find((key) => SHOCK_LEVEL[key] === trip.shockLevel)];
   let capacity = trip.capacity;
   let timetables = trip.timetables;
-  let newDateTimetables = [];
 
   async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
     switch (e.detail.action) {
       case 'updateTrip':
-        newDateTimetables = await timetables.map((timetable) => {
-          return { stop: timetable.stop, time: formatPickupTime(timetable.time) };
-        });
-
         await updateTrip();
         break;
       default:
@@ -50,7 +45,9 @@
         name: tripName,
         shockLevel: SHOCK_LEVEL[Object.keys(SHOCK_LEVEL_LABEL).find((key) => SHOCK_LEVEL_LABEL[key] === value)],
         capacity: capacity,
-        timetables: newDateTimetables,
+        timetables: timetables.map((timetable) => {
+          return { stop: timetable.stop, time: formatPickupTime(timetable.time) };
+        }),
       });
       addToast({
         message: '便を編集しました。',

--- a/web/app/src/pages/logistics/setting/_components/TripEditDialog.svelte
+++ b/web/app/src/pages/logistics/setting/_components/TripEditDialog.svelte
@@ -3,6 +3,7 @@
   import Dialog, { Title, Actions, Content } from '@smui/dialog';
   import Select, { Option } from '@smui/select';
   import Textfield from '@smui/textfield';
+  import dayjs from 'dayjs';
   import { SHOCK_LEVEL, SHOCK_LEVEL_LABEL } from '../../../../constants/product';
   import {
     LogisticsRepository,
@@ -29,17 +30,11 @@
   async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
     switch (e.detail.action) {
       case 'updateTrip':
-        newDateTimetables = timetables.map((value, index) => {
-          const [id, stop, time, tripId] = [
-            trip.timetables[index].id,
-            value.stop,
-            changeFormatDate(value.time),
-            trip.id,
-          ];
-          return { id, stop, time, tripId };
+        newDateTimetables = timetables.map((timetable) => {
+          return { stop: timetable.stop, time: dayjs(timetable.time).toISOString() };
         });
 
-        await updateTrip(trip.id);
+        await updateTrip();
         break;
       default:
         // NOP
@@ -49,23 +44,9 @@
     cancelInputData();
   }
 
-  function changeFormatDate(time: string) {
-    if (!time) {
-      return;
-    }
-    if (time.length > 6) {
-      return new Date(time);
-    }
-    const today = new Date();
-    today.setHours(Number(time.substring(0, 2)));
-    today.setMinutes(Number(time.substring(3)));
-    today.setSeconds(0);
-    return today;
-  }
-
-  async function updateTrip(tripId: string) {
+  async function updateTrip() {
     try {
-      logisticsSetting = await logisticsRepository.updateTrip(logisticsSetting.logisticsId, tripId, {
+      logisticsSetting = await logisticsRepository.updateTrip(logisticsSetting.logisticsId, route.id, trip.id, {
         name: tripName,
         shockLevel: SHOCK_LEVEL[Object.keys(SHOCK_LEVEL_LABEL).find((key) => SHOCK_LEVEL_LABEL[key] === value)],
         capacity: capacity,

--- a/web/app/src/pages/logistics/setting/_components/TripEditDialog.svelte
+++ b/web/app/src/pages/logistics/setting/_components/TripEditDialog.svelte
@@ -3,7 +3,6 @@
   import Dialog, { Title, Actions, Content } from '@smui/dialog';
   import Select, { Option } from '@smui/select';
   import Textfield from '@smui/textfield';
-  import dayjs from 'dayjs';
   import { SHOCK_LEVEL, SHOCK_LEVEL_LABEL } from '../../../../constants/product';
   import {
     LogisticsRepository,
@@ -30,8 +29,12 @@
   async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
     switch (e.detail.action) {
       case 'updateTrip':
-        newDateTimetables = timetables.map((timetable) => {
-          return { stop: timetable.stop, time: dayjs(timetable.time).toISOString() };
+        newDateTimetables = await timetables.map((timetable) => {
+          const day = new Date();
+          day.setHours(timetable.time.slice(0, 2));
+          day.setMinutes(timetable.time.slice(3));
+          day.setSeconds(0);
+          return { stop: timetable.stop, time: day };
         });
 
         await updateTrip();

--- a/web/app/src/pages/logistics/setting/_components/TripEditDialog.svelte
+++ b/web/app/src/pages/logistics/setting/_components/TripEditDialog.svelte
@@ -3,6 +3,7 @@
   import Dialog, { Title, Actions, Content } from '@smui/dialog';
   import Select, { Option } from '@smui/select';
   import Textfield from '@smui/textfield';
+  import dayjs from 'dayjs';
   import { SHOCK_LEVEL, SHOCK_LEVEL_LABEL } from '../../../../constants/product';
   import {
     LogisticsRepository,
@@ -30,11 +31,7 @@
     switch (e.detail.action) {
       case 'updateTrip':
         newDateTimetables = await timetables.map((timetable) => {
-          const day = new Date();
-          day.setHours(timetable.time.slice(0, 2));
-          day.setMinutes(timetable.time.slice(3));
-          day.setSeconds(0);
-          return { stop: timetable.stop, time: day };
+          return { stop: timetable.stop, time: formatPickupTime(timetable.time) };
         });
 
         await updateTrip();
@@ -75,6 +72,16 @@
       capacity = 100;
     } else if (capacity < 1) {
       capacity = 1;
+    }
+  }
+
+  function formatPickupTime(timeString) {
+    if (dayjs(timeString, 'hh:mm', true).isValid()) {
+      return dayjs(timeString, 'hh:mm', true).toDate();
+    } else if (dayjs(timeString).isValid()) {
+      return timeString;
+    } else {
+      return '';
     }
   }
 </script>

--- a/web/app/src/pages/logistics/setting/_components/TripEditDialog.svelte
+++ b/web/app/src/pages/logistics/setting/_components/TripEditDialog.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import Button from '@smui/button';
+  import Dialog, { Title, Actions, Content } from '@smui/dialog';
+  import Select, { Option } from '@smui/select';
+  import Textfield from '@smui/textfield';
+  import { SHOCK_LEVEL, SHOCK_LEVEL_LABEL } from '../../../../constants/product';
+  import { LogisticsRepository, type TLogisticsSetting } from '../../../../models/Logistics';
+  import { addToast } from '../../../../stores/Toast';
+  import { handleError } from '../../../../utils/error-handle-helper';
+  import TimetableImport from './TimetableImport.svelte';
+
+  const shockLevels = ['とても強い', '強い', '弱い', 'とても弱い'];
+  let logisticsRepository: LogisticsRepository = new LogisticsRepository();
+  export let logisticsSetting: TLogisticsSetting = null;
+  export let open = false;
+  export let trip;
+  export let routeId;
+  let tripName = trip.name;
+  let value = SHOCK_LEVEL_LABEL[Object.keys(SHOCK_LEVEL).find((key) => SHOCK_LEVEL[key] === trip.shockLevel)];
+  let capacity = trip.capacity;
+  let timetables = trip.timetables;
+  let newDateTimetables = [];
+
+  async function onDialogClosedHandle(e: CustomEvent<{ action: string }>) {
+    switch (e.detail.action) {
+      case 'updateTrip':
+        newDateTimetables = timetables.map((value) => {
+          const [stop, time] = [value.stop, changeFormatDate(value.time)];
+          return { stop, time };
+        });
+
+        await updateTrip(trip.id);
+        break;
+      default:
+        // NOP
+        break;
+    }
+
+    cancelInputData();
+  }
+
+  function changeFormatDate(time: string) {
+    if (!time) {
+      return;
+    }
+    if (time.length > 6) {
+      return new Date(time);
+    }
+    const today = new Date();
+    today.setHours(Number(time.substring(0, 2)));
+    today.setMinutes(Number(time.substring(3)));
+    today.setSeconds(0);
+    return today;
+  }
+
+  async function updateTrip(tripId: string) {
+    try {
+      logisticsSetting = await logisticsRepository.updateTrip(logisticsSetting.logisticsId, tripId, {
+        name: tripName,
+        shockLevel: SHOCK_LEVEL[Object.keys(SHOCK_LEVEL_LABEL).find((key) => SHOCK_LEVEL_LABEL[key] === value)],
+        capacity: capacity,
+        timetables: newDateTimetables,
+      });
+      addToast({
+        message: '便を編集しました。',
+      });
+    } catch (err) {
+      handleError(err, '便の編集');
+    }
+  }
+
+  function cancelInputData() {
+    tripName = trip.name;
+    value = SHOCK_LEVEL_LABEL[Object.keys(SHOCK_LEVEL).find((key) => SHOCK_LEVEL[key] === trip.shockLevel)];
+    capacity = trip.capacity;
+    timetables = trip.timetables;
+  }
+
+  function inputNumberLimited() {
+    if (capacity > 100) {
+      capacity = 100;
+    } else if (capacity < 1) {
+      capacity = 1;
+    }
+  }
+</script>
+
+<Dialog bind:open on:SMUIDialog:closed={onDialogClosedHandle} container$class="max-h-[80vh]">
+  <Title>運航便を編集します。</Title>
+  <Content>
+    <div class="justify-left ml-8 mr-8">
+      <Textfield
+        class="w-[300px]"
+        label="便名"
+        bind:value={tripName}
+        type={'text'}
+        input$maxlength={50}
+        input$placeholder="便名"
+        required
+      />
+      <h1 class="mt-3 border-l-8 border-solid border-l-primary bg-[#f4f4f4] px-3 py-2 text-lg text-[#494949]">
+        <span>車両</span>
+      </h1>
+      <div class="ml-3">
+        <div>
+          <Select bind:value label="衝撃">
+            {#each shockLevels as shockLevel}
+              <Option value={shockLevel}>{shockLevel}</Option>
+            {/each}
+          </Select>
+        </div>
+        <div>
+          <Textfield
+            class="mt-3 w-[300px]"
+            label="最大取扱い量"
+            bind:value={capacity}
+            type={'number'}
+            input$max={100}
+            input$min={1}
+            input$placeholder="最大取り扱い量"
+            suffix="予約"
+            on:input={inputNumberLimited}
+            required
+          />
+        </div>
+      </div>
+      <h1 class="mt-3 border-l-8 border-solid border-l-primary bg-[#f4f4f4] px-3 py-2 text-lg text-[#494949]">
+        <span>時刻表</span>
+      </h1>
+      <TimetableImport bind:timetables {routeId} kinds="edit" />
+    </div>
+  </Content>
+
+  <Actions style="display: flex; justify-content: center">
+    <Button class="w-[150px] rounded-full px-4 py-2" color="secondary" variant="outlined">
+      <p class="text-lg font-bold">キャンセル</p>
+    </Button>
+    <Button
+      class="w-[150px] rounded-full px-4 py-2"
+      color="secondary"
+      variant="raised"
+      action="updateTrip"
+      disabled={!tripName || !value || !capacity}
+    >
+      <p class="text-lg font-bold">編集</p>
+    </Button>
+  </Actions>
+</Dialog>


### PR DESCRIPTION
## 概要
物流業者向け物流設定画面で行う「便編集」の機能追加

## 変更点
(Frontend)
・便編集ダイアログのコンポーネントを作成（TripEditDialog）
・時刻表をCSVファイルから読み込むコンポーネントの日付フォーマット修正（TimetableImport）
・LogisticsTripAccordionから便編集ダイアログを呼び出すよう変更

(back)
・便追加APIを作成  PUT .../setting/logistics/:logisticsId/route/:routeId/trip/:tripId

## 動作確認内容
・便accordionに表示されているアイコンボタン押下時にダイアログが表示されること
・ダイアログ開いた際に初期データが入っているか
・テキストエリアに便名が入力できること
・衝撃セレクトメニューに必要項目がすべて表示されていること
・最大値取り扱い量入力テキストエリアの入力値の最大と最小が機能しているか
・必須項目（便名、衝撃、最大取り扱い量）が入力されてなければ追加ボタンを押下できないこと
・それぞれのダイアログで独立して動作できるか
・CSVインポート時、表が更新されるか
・編集完了時、物流業者向け物流設定画面が更新されるか