### PR TITLE
物流業者向け物流設定画面の路線、便、時刻表のソート

### DIFF
--- a/server/app/src/logistics/logistics.service.ts
+++ b/server/app/src/logistics/logistics.service.ts
@@ -47,9 +47,29 @@ export class LogisticsService {
   ) {}
 
   async getLogisticsSetting(logisticsId: string): Promise<LogisticsSettingForLogistics> {
-    return await this.logisticsSettingRepository
-      .findOne({ where: { logisticsId }, relations: ['routes', 'routes.trips', 'routes.trips.timetables'] })
-      .then((setting) => setting);
+    const setting = await this.logisticsSettingRepository
+      .findOne({
+        where: { logisticsId },
+        relations: ['routes', 'routes.trips', 'routes.trips.timetables'],
+        order: {
+          routes: {
+            name: 'ASC',
+            trips: {
+              name: 'ASC',
+              timetables: {
+                time: 'ASC',
+              },
+            },
+          },
+        },
+      })
+      .then((setting) => setting)
+      .catch(() => null);
+
+    if (!setting) {
+      throw new BadRequestException();
+    }
+    return setting;
   }
 
   async getProducerSetting(producerId: string): Promise<LogisticsSettingForProducer> {
@@ -113,18 +133,7 @@ export class LogisticsService {
     this.setRouteAttributes(dto, route);
     await route.save();
 
-    const setting = await this.logisticsSettingRepository
-      .findOne({
-        where: { logisticsId },
-        relations: ['routes', 'routes.trips', 'routes.trips.timetables'],
-      })
-      .then((setting) => setting);
-
-    if (!setting) {
-      throw new BadRequestException();
-    }
-
-    return setting;
+    return await this.getLogisticsSetting(logisticsId);
   }
 
   async deleteRoute(account: Account, logisticsId: string, routeId: string): Promise<LogisticsSettingForLogistics> {
@@ -142,14 +151,7 @@ export class LogisticsService {
     const route = await this.routeRepository.findOne({ where: { id: routeId } });
     await this.routeRepository.remove(route);
 
-    const resSetting = await this.logisticsSettingRepository
-      .findOne({
-        where: { logisticsId },
-        relations: ['routes', 'routes.trips', 'routes.trips.timetables'],
-      })
-      .then((setting) => setting);
-
-    return resSetting;
+    return await this.getLogisticsSetting(logisticsId);
   }
 
   private setRouteAttributes(dto: CreateRouteDto, route: Route) {
@@ -179,18 +181,7 @@ export class LogisticsService {
       await manager.save(timetables);
     });
 
-    const setting = await this.logisticsSettingRepository
-      .findOne({
-        where: { logisticsId },
-        relations: ['routes', 'routes.trips', 'routes.trips.timetables'],
-      })
-      .then((setting) => setting);
-
-    if (!setting) {
-      throw new BadRequestException();
-    }
-
-    return setting;
+    return await this.getLogisticsSetting(logisticsId);
   }
 
   async updateTrip(
@@ -244,18 +235,7 @@ export class LogisticsService {
       await manager.save(trip);
     });
 
-    const setting = await this.logisticsSettingRepository
-      .findOne({
-        where: { logisticsId },
-        relations: ['routes', 'routes.trips', 'routes.trips.timetables'],
-      })
-      .then((setting) => setting);
-
-    if (!setting) {
-      throw new BadRequestException();
-    }
-
-    return setting;
+    return await this.getLogisticsSetting(logisticsId);
   }
 
   private setTripAttributes(routeId: string, dto: CreateTripDto, trip: Trip) {
@@ -294,18 +274,7 @@ export class LogisticsService {
     const trip = await this.tripRepository.findOne({ where: { id: tripId } });
     await this.tripRepository.remove(trip);
 
-    const setting = await this.logisticsSettingRepository
-      .findOne({
-        where: { logisticsId },
-        relations: ['routes', 'routes.trips', 'routes.trips.timetables'],
-      })
-      .then((setting) => setting);
-
-    if (!setting) {
-      throw new BadRequestException();
-    }
-
-    return setting;
+    return await this.getLogisticsSetting(logisticsId);
   }
 
   async updateDeliveryType(logisticsId: string, dto: UpdateDeliveryTypeDto): Promise<LogisticsSettingForLogistics> {
@@ -337,18 +306,7 @@ export class LogisticsService {
     route.name = dto.name;
     await this.routeRepository.save(route);
 
-    const setting = await this.logisticsSettingRepository
-      .findOne({
-        where: { logisticsId },
-        relations: ['routes', 'routes.trips', 'routes.trips.timetables'],
-      })
-      .then((setting) => setting);
-
-    if (!setting) {
-      throw new BadRequestException();
-    }
-
-    return setting;
+    return await this.getLogisticsSetting(logisticsId);
   }
 
   async createShippingSchedule(dto: CreateShippingScheduleDto): Promise<ShippingSchedule> {


### PR DESCRIPTION
# 概要

物流業者向け物流設定画面の路線、便、時刻表がソートされるように対応

# 変更点
  
* 路線や便の追加、編集、削除において操作するたびに表示順が変わってしまう使いずらさがあったためソートするように改善
  * 路線は路線名の昇順
  * 便は便名の昇順
  * 時刻表は時刻の昇順
* 物流業者向け物流設定のAPIにおいて追加、編集、削除の操作では設定をレスポンスにしていたが同様の処理が散見されたため１メソッドに集約（エラー処理（主にcatch）等適切に行われていない部分も改善）

# 動作確認内容

* 物流業者向け物流設定画面の表示において、路線、便、時刻表がそれぞれ昇順にソートされ、表示されてていることを確認
* 路線を追加した際に、追加した路線を含め設定全体を通して路線、便、時刻表がそれぞれ昇順にソートされていることを確認
* 路線を編集した際に、編集した路線を含め設定全体を通して路線、便、時刻表がそれぞれ昇順にソートされていることを確認 
* 路線を削除した際に、追加した路線を含め設定全体を通して路線、便、時刻表がそれぞれ昇順にソートされていることを確認
* 便を追加した際に、追加した便を含め設定全体を通して路線、便、時刻表がそれぞれ昇順にソートされていることを確認
* 便を編集した際に、編集した便を含め設定全体を通して路線、便、時刻表がそれぞれ昇順にソートされていることを確認 
* 便を削除した際に、追加した便を含め設定全体を通して路線、便、時刻表がそれぞれ昇順にソートされていることを確認
* 時刻表がある場合に上記の動作確認を行っても、路線、便、時刻表がそれぞれ昇順にソートされていることを確認

