### PR TITLE
配送便候補取得APIに衝撃のフィルタ条件を追加

### DIFF
--- a/server/app/src/logistics/logistics.controller.ts
+++ b/server/app/src/logistics/logistics.controller.ts
@@ -129,6 +129,7 @@ export class LogisticsController {
     @Query('delivery-stop') deliveryStop: string,
     @Query('count') count: number,
     @Query('date') date: string,
+    @Query('conditions') conditions: string,
   ) {
     return await this.logisticService.getTripSuggestions(
       logisticsId,
@@ -136,6 +137,7 @@ export class LogisticsController {
       deliveryStop,
       count,
       dayjs(date).toDate(),
+      conditions || '[]',
     );
   }
 

--- a/server/app/src/logistics/logistics.service.ts
+++ b/server/app/src/logistics/logistics.service.ts
@@ -563,31 +563,22 @@ function checkMeetConditionsTrip(suggestTrip: TSuggestTrip, conditions: Array<Su
 }
 
 function getOperatorFn(operator: string) {
-  let fn;
   switch (operator) {
     case OPERATORS.equal:
-      fn = (param: number, value: number) => param === value;
-      break;
+      return (param: number, value: number) => param === value;
     case OPERATORS.notEqual:
-      fn = (param: number, value: number) => param !== value;
-      break;
+      return (param: number, value: number) => param !== value;
     case OPERATORS.greaterThan:
-      fn = (param: number, value: number) => param > value;
-      break;
+      return (param: number, value: number) => param > value;
     case OPERATORS.lessThan:
-      fn = (param: number, value: number) => param < value;
-      break;
+      return (param: number, value: number) => param < value;
     case OPERATORS.greaterEqual:
-      fn = (param: number, value: number) => param >= value;
-      break;
+      return (param: number, value: number) => param >= value;
     case OPERATORS.lessEqual:
-      fn = (param: number, value: number) => param <= value;
-      break;
+      return (param: number, value: number) => param <= value;
     default:
-      fn = () => true;
-      break;
+      return () => true;
   }
-  return fn;
 }
 
 const OPERATORS = {

--- a/server/app/src/migrations/1690362384516-InsertMasterDataInDB.ts
+++ b/server/app/src/migrations/1690362384516-InsertMasterDataInDB.ts
@@ -37,35 +37,35 @@ export class InsertMasterDataInDB1690362384516 implements MigrationInterface {
     );
     // 便（上り）
     await queryRunner.query(
-      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('9e860e2b-0ffc-464d-84b7-b66926253aa4', '4d44a591-5924-4239-a46c-23d8134f9ff4', '1便', 60, 10)`,
+      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('9e860e2b-0ffc-464d-84b7-b66926253aa4', '4d44a591-5924-4239-a46c-23d8134f9ff4', '1便', 45, 10)`,
     );
     await queryRunner.query(
-      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('4d44a591-5924-4239-a46c-23d8134f9ff2', '4d44a591-5924-4239-a46c-23d8134f9ff4', '2便', 45, 10)`,
+      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('4d44a591-5924-4239-a46c-23d8134f9ff2', '4d44a591-5924-4239-a46c-23d8134f9ff4', '2便', 60, 10)`,
     );
     await queryRunner.query(
-      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('1466f21f-72d2-4c84-b394-da366b82e07a', '4d44a591-5924-4239-a46c-23d8134f9ff4', '3便', 60, 10)`,
+      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('1466f21f-72d2-4c84-b394-da366b82e07a', '4d44a591-5924-4239-a46c-23d8134f9ff4', '3便', 45, 10)`,
     );
     await queryRunner.query(
-      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('71726b3c-dd4e-4e2e-afb7-d032d4cc0b95', '4d44a591-5924-4239-a46c-23d8134f9ff4', '4便', 45, 10)`,
+      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('71726b3c-dd4e-4e2e-afb7-d032d4cc0b95', '4d44a591-5924-4239-a46c-23d8134f9ff4', '4便', 60, 10)`,
     );
     await queryRunner.query(
-      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('5fbb8335-e596-4d6d-b7a4-30b71dbd540b', '4d44a591-5924-4239-a46c-23d8134f9ff4', '5便', 60, 10)`,
+      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('5fbb8335-e596-4d6d-b7a4-30b71dbd540b', '4d44a591-5924-4239-a46c-23d8134f9ff4', '5便', 45, 10)`,
     );
     // 便（下り）
     await queryRunner.query(
-      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('f5303601-e7bb-4277-af09-8a9750c30b11', '2e9c5a4a-0519-4d47-b259-d5a5f4a76728', '1便', 60, 10)`,
+      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('f5303601-e7bb-4277-af09-8a9750c30b11', '2e9c5a4a-0519-4d47-b259-d5a5f4a76728', '1便', 45, 10)`,
     );
     await queryRunner.query(
-      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('5a041d1c-52b9-4c3b-aaa4-125478729c39', '2e9c5a4a-0519-4d47-b259-d5a5f4a76728', '2便', 45, 10)`,
+      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('5a041d1c-52b9-4c3b-aaa4-125478729c39', '2e9c5a4a-0519-4d47-b259-d5a5f4a76728', '2便', 60, 10)`,
     );
     await queryRunner.query(
-      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('116435fa-5adf-46a7-a00b-36b2bd7a7aff', '2e9c5a4a-0519-4d47-b259-d5a5f4a76728', '3便', 60, 10)`,
+      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('116435fa-5adf-46a7-a00b-36b2bd7a7aff', '2e9c5a4a-0519-4d47-b259-d5a5f4a76728', '3便', 45, 10)`,
     );
     await queryRunner.query(
-      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('612ce9a2-810d-48b5-b54a-b87b75612c9e', '2e9c5a4a-0519-4d47-b259-d5a5f4a76728', '4便', 45, 10)`,
+      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('612ce9a2-810d-48b5-b54a-b87b75612c9e', '2e9c5a4a-0519-4d47-b259-d5a5f4a76728', '4便', 60, 10)`,
     );
     await queryRunner.query(
-      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('b3ba9859-9886-4b39-b676-e401d6cc7e58', '2e9c5a4a-0519-4d47-b259-d5a5f4a76728', '5便', 60, 10)`,
+      `INSERT INTO trip (id, route_id, name, shock_level, capacity) VALUES ('b3ba9859-9886-4b39-b676-e401d6cc7e58', '2e9c5a4a-0519-4d47-b259-d5a5f4a76728', '5便', 45, 10)`,
     );
     // 時刻表（上り 1便）
     await queryRunner.query(

--- a/web/app/src/models/Logistics.ts
+++ b/web/app/src/models/Logistics.ts
@@ -104,9 +104,10 @@ export class LogisticsRepository {
     pickupStop: string,
     deliveryStop: string,
     count: number,
+    conditions: string,
   ): Promise<Record<string, string>[]> {
     return await baseAPI<Record<string, string>[]>({
-      endpoint: `${this.baseEndpoint}/tripsuggestions?logisticsId=${logisticsId}&pickup-stop=${pickupStop}&delivery-stop=${deliveryStop}&count=${count}`,
+      endpoint: `${this.baseEndpoint}/tripsuggestions?logisticsId=${logisticsId}&pickup-stop=${pickupStop}&delivery-stop=${deliveryStop}&count=${count}&conditions=${conditions}`,
     });
   }
 

--- a/web/app/src/pages/reservation/[id]/index.svelte
+++ b/web/app/src/pages/reservation/[id]/index.svelte
@@ -157,6 +157,7 @@
           bind:reservationStatus
           pickupStop={reservationData.product.producer.logisticsSettingForProducer.stop}
           deliveryStop={reservationData.receiveLocation.logisticsSettingForIntermediary.stop}
+          shockLevel={reservationData.product.shockLevel}
         />
       {/if}
       {#if canKept(reservationData)}

--- a/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
+++ b/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
@@ -83,7 +83,8 @@
     const conditions = JSON.stringify([
       {
         property: 'shockLevel',
-        operator: 'lessEqual',
+        operator: 'greaterEqual',
+        type: 'number',
         value: shockLevel,
       },
     ]);

--- a/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
+++ b/web/app/src/pages/reservation/_components/PackedWizardDialog.svelte
@@ -23,6 +23,7 @@
   export let reservationStatus: TReservation['status'];
   export let pickupStop: string;
   export let deliveryStop: string;
+  export let shockLevel: number;
 
   $: reservationRepository = new ReservationRepository();
 
@@ -79,12 +80,20 @@
 
   async function fetchTripSuggestions(): Promise<TSuggestTrip[]> {
     selectedTrip = null;
+    const conditions = JSON.stringify([
+      {
+        property: 'shockLevel',
+        operator: 'lessEqual',
+        value: shockLevel,
+      },
+    ]);
     try {
       suggestions = await new LogisticsRepository().getTripSuggestions(
         selectedShipper.id,
         pickupStop,
         deliveryStop,
         MAX_SUGGEST_TRIP_COUNT,
+        conditions,
       );
       return suggestions;
     } catch (err) {


### PR DESCRIPTION
# 概要

* 配送便候補取得APIに衝撃のフィルタ条件を追加しました。
  * メソッドはGETのままとし、以下のようなデータをJSON.stringifyしてクエリに持たせます。
  * サーバーサイドで、property、value、operatorの条件に合致する候補に絞り込みます。
    (operatorの種類は server/app/src/logistics/logistics.service.ts の OPERATORS を参照)
```json
{
  "property": "shockLevel",
  "operator": "greaterEqual",
  "type": "number",
  "value": 45
}
```

# 変更点
  
* (web)

  * 配送便候補選択ウィザードから実行するAPIに conditions パラメータを追加

* (back)

  * 配送便取得候補APIで conditions パラメータに設定した値で便候補を絞り込む処理を追加
  * マスタデータの便に設定されている衝撃の値を修正
    * (車両の)衝撃が少ない＝許容可能な衝撃度合いの幅が増える＝数値が下がる
--------
[混載・物流定義](https://satisfying-sailboat-d9f.notion.site/eabe0b2470da4e759635fabb0b1cda24) 資料より

<img width="302" alt="スクリーンショット 2023-12-13 16 51 12" src="https://github.com/NS-APU/BabaCafe/assets/57512638/2277f606-dc1f-43be-93a1-b2dd7fec3d00">

--------

# 動作確認内容

* 16:30 に配送便の選択ウィザードを「下岩川地区ふれあいバス」に設定したとき

  * 衝撃に強い作物の場合、翌日の1~3便が候補に出る(全ての便がヒットする)
![スクリーンショット 2023-12-13 17 02 30](https://github.com/NS-APU/BabaCafe/assets/57512638/f9145a31-21ac-46b1-9cb8-0d4736a8b212)

  * 衝撃に弱い作物の場合、翌日の1便/3便/5便が候補に出る(衝撃が少ない便のみがヒットする)
![スクリーンショット 2023-12-13 17 02 44](https://github.com/NS-APU/BabaCafe/assets/57512638/fd8492bc-0df4-4bf0-a6ca-13961e4125d9)
